### PR TITLE
Dev

### DIFF
--- a/jakartaee/platform/8/TCKResults.adoc
+++ b/jakartaee/platform/8/TCKResults.adoc
@@ -11,7 +11,7 @@ https://openliberty.io/downloads[Open Liberty 19.0.0.6]
 
 * Specification Name, Version and download URL:
 +
-https://jakarta.ee/specifications/[Jakarta EE Platform 8]
+https://jakarta.ee/specifications/platform/8[Jakarta EE Platform 8]
 
 * TCK Version, digital SHA-256 fingerprint and download URL:
 +
@@ -43,6 +43,10 @@ OpenJDK 8 + HotSpot (jdk8u222-b10)
 +
 Apache Derby, Linux, Ubuntu 18.04
 
+* Challenges
++
+https://github.com/eclipse-ee4j/faces-api/issues/1474[JSF Signature Test Challenge (signaturetest)]
+
 Test Results:
 
 ----
@@ -54,7 +58,7 @@ Stage Name: appclient
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: assembly
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 30 tests.
@@ -78,7 +82,7 @@ Stage Name: concurrency/api
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: concurrency/spec/ContextService
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 11 tests.
@@ -86,7 +90,7 @@ Stage Name: concurrency/spec/ContextService
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: concurrency/spec/ManagedExecutorService
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 15 tests.
@@ -126,7 +130,7 @@ Stage Name: ejb30/assembly/appres/appclientejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/appres/warejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -134,7 +138,7 @@ Stage Name: ejb30/assembly/appres/warejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/appres/warmbean
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -142,7 +146,7 @@ Stage Name: ejb30/assembly/appres/warmbean
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/initorder/appclientejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -150,7 +154,7 @@ Stage Name: ejb30/assembly/initorder/appclientejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/initorder/ejbwar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -158,7 +162,7 @@ Stage Name: ejb30/assembly/initorder/ejbwar
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/initorder/warejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -166,7 +170,7 @@ Stage Name: ejb30/assembly/initorder/warejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/librarydirectory/custom
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 10 tests.
@@ -174,7 +178,7 @@ Stage Name: ejb30/assembly/librarydirectory/custom
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/librarydirectory/defaultname
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -182,7 +186,7 @@ Stage Name: ejb30/assembly/librarydirectory/defaultname
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/librarydirectory/disable
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -190,7 +194,7 @@ Stage Name: ejb30/assembly/librarydirectory/disable
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/mbean/appclient
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -198,7 +202,7 @@ Stage Name: ejb30/assembly/mbean/appclient
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/metainf/appclientejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -206,7 +210,7 @@ Stage Name: ejb30/assembly/metainf/appclientejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/assembly/metainfandlibdir
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 5 tests.
@@ -222,7 +226,7 @@ Stage Name: ejb30/bb/async
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/localaccess
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 50 tests.
@@ -230,7 +234,7 @@ Stage Name: ejb30/bb/localaccess
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -238,7 +242,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/complement
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -246,7 +250,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/complement
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -254,7 +258,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/override
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -262,7 +266,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectorauto/override
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -270,7 +274,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/complement
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -278,7 +282,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/complement
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -286,7 +290,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/override
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -294,7 +298,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/queue/selectordups/override
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -302,7 +306,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/complement
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -310,7 +314,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/complemen
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -318,7 +322,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/descripto
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/override
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -326,7 +330,7 @@ Stage Name: ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/override
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/callback/listener/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -334,7 +338,7 @@ Stage Name: ejb30/bb/mdb/callback/listener/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/callback/listener/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -342,7 +346,7 @@ Stage Name: ejb30/bb/mdb/callback/listener/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/callback/method/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -350,7 +354,7 @@ Stage Name: ejb30/bb/mdb/callback/method/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/callback/method/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -358,7 +362,7 @@ Stage Name: ejb30/bb/mdb/callback/method/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/callback/method/ejbcreate
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -366,7 +370,7 @@ Stage Name: ejb30/bb/mdb/callback/method/ejbcreate
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/customlistener
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -374,7 +378,7 @@ Stage Name: ejb30/bb/mdb/customlistener
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/fullpath
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -382,7 +386,7 @@ Stage Name: ejb30/bb/mdb/dest/fullpath
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/jarwar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -390,7 +394,7 @@ Stage Name: ejb30/bb/mdb/dest/jarwar
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/onejar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -398,7 +402,7 @@ Stage Name: ejb30/bb/mdb/dest/onejar
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/optional
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -414,7 +418,7 @@ Stage Name: ejb30/bb/mdb/dest/optional2
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/topic/fullpath
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -422,7 +426,7 @@ Stage Name: ejb30/bb/mdb/dest/topic/fullpath
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/topic/jarwar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -430,7 +434,7 @@ Stage Name: ejb30/bb/mdb/dest/topic/jarwar
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/topic/onejar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -446,7 +450,7 @@ Stage Name: ejb30/bb/mdb/dest/topic/twojars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/dest/twojars
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -454,7 +458,7 @@ Stage Name: ejb30/bb/mdb/dest/twojars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/interceptor/listener/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 7 tests.
@@ -462,7 +466,7 @@ Stage Name: ejb30/bb/mdb/interceptor/listener/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/interceptor/listener/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 7 tests.
@@ -470,7 +474,7 @@ Stage Name: ejb30/bb/mdb/interceptor/listener/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/interceptor/method/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -478,7 +482,7 @@ Stage Name: ejb30/bb/mdb/interceptor/method/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/interceptor/method/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -486,7 +490,7 @@ Stage Name: ejb30/bb/mdb/interceptor/method/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/listenerintf/implementing/externalizable
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -494,7 +498,7 @@ Stage Name: ejb30/bb/mdb/listenerintf/implementing/externalizable
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/mdb/listenerintf/implementing/serializable
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -502,7 +506,7 @@ Stage Name: ejb30/bb/mdb/listenerintf/implementing/serializable
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/session/stateful
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 350 tests.
@@ -510,7 +514,7 @@ Stage Name: ejb30/bb/session/stateful
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/bb/session/stateless
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 397 tests.
@@ -526,7 +530,7 @@ Stage Name: ejb30/lite/appexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/async
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 300 tests.
@@ -534,7 +538,7 @@ Stage Name: ejb30/lite/async
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/basic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 84 tests.
@@ -542,7 +546,7 @@ Stage Name: ejb30/lite/basic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/ejbcontext
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 40 tests.
@@ -550,7 +554,7 @@ Stage Name: ejb30/lite/ejbcontext
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/enventry
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -558,7 +562,7 @@ Stage Name: ejb30/lite/enventry
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/interceptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 140 tests.
@@ -566,7 +570,7 @@ Stage Name: ejb30/lite/interceptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/lookup
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -574,7 +578,7 @@ Stage Name: ejb30/lite/lookup
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/naming
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 44 tests.
@@ -582,7 +586,7 @@ Stage Name: ejb30/lite/naming
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/nointerface
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 48 tests.
@@ -590,7 +594,7 @@ Stage Name: ejb30/lite/nointerface
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/packaging
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 203 tests.
@@ -606,7 +610,7 @@ Stage Name: ejb30/lite/singleton
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/stateful/concurrency
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 68 tests.
@@ -614,7 +618,7 @@ Stage Name: ejb30/lite/stateful/concurrency
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/stateful/timeout
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 22 tests.
@@ -622,7 +626,7 @@ Stage Name: ejb30/lite/stateful/timeout
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/tx
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 300 tests.
@@ -630,7 +634,7 @@ Stage Name: ejb30/lite/tx
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/view
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 76 tests.
@@ -638,7 +642,7 @@ Stage Name: ejb30/lite/view
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/lite/xmloverride
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -654,7 +658,7 @@ Stage Name: ejb30/misc/datasource/appclientejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/datasource/twojars
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -662,7 +666,7 @@ Stage Name: ejb30/misc/datasource/twojars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/datasource/twowars
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -670,7 +674,7 @@ Stage Name: ejb30/misc/datasource/twowars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/getresource/appclient
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 10 tests.
@@ -678,7 +682,7 @@ Stage Name: ejb30/misc/getresource/appclient
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/getresource/warejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 20 tests.
@@ -686,7 +690,7 @@ Stage Name: ejb30/misc/getresource/warejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/jndi/earjar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 11 tests.
@@ -694,7 +698,7 @@ Stage Name: ejb30/misc/jndi/earjar
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/jndi/earwar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 7 tests.
@@ -702,7 +706,7 @@ Stage Name: ejb30/misc/jndi/earwar
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/jndi/earwarjar
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 5 tests.
@@ -710,7 +714,7 @@ Stage Name: ejb30/misc/jndi/earwarjar
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/metadataComplete/appclient2ejbjars
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -718,7 +722,7 @@ Stage Name: ejb30/misc/metadataComplete/appclient2ejbjars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/metadataComplete/appclientejbjars
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -726,7 +730,7 @@ Stage Name: ejb30/misc/metadataComplete/appclientejbjars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/metadataComplete/warejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 9 tests.
@@ -734,7 +738,7 @@ Stage Name: ejb30/misc/metadataComplete/warejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/moduleName/appclientejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -742,7 +746,7 @@ Stage Name: ejb30/misc/moduleName/appclientejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/moduleName/conflict
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -750,7 +754,7 @@ Stage Name: ejb30/misc/moduleName/conflict
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/moduleName/twojars
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -758,7 +762,7 @@ Stage Name: ejb30/misc/moduleName/twojars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/moduleName/twowars
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -766,7 +770,7 @@ Stage Name: ejb30/misc/moduleName/twowars
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/nomethodbean
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -774,7 +778,7 @@ Stage Name: ejb30/misc/nomethodbean
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/sameejbclass
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -782,7 +786,7 @@ Stage Name: ejb30/misc/sameejbclass
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/threebeans
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -790,7 +794,7 @@ Stage Name: ejb30/misc/threebeans
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/misc/xmloverride/ejbref
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -806,7 +810,7 @@ Stage Name: ejb30/sec/permsxml
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateful/lsecp
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -814,7 +818,7 @@ Stage Name: ejb30/sec/stateful/lsecp
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateful/lsecr
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -822,7 +826,7 @@ Stage Name: ejb30/sec/stateful/lsecr
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateful/sec
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -830,7 +834,7 @@ Stage Name: ejb30/sec/stateful/sec
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateful/secpropagation
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -838,7 +842,7 @@ Stage Name: ejb30/sec/stateful/secpropagation
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateful/secrunaspropagation
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 11 tests.
@@ -846,7 +850,7 @@ Stage Name: ejb30/sec/stateful/secrunaspropagation
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateless/lsecp
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -854,7 +858,7 @@ Stage Name: ejb30/sec/stateless/lsecp
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateless/lsecr
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -862,7 +866,7 @@ Stage Name: ejb30/sec/stateless/lsecr
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateless/sec
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -870,7 +874,7 @@ Stage Name: ejb30/sec/stateless/sec
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateless/secpropagation
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -878,7 +882,7 @@ Stage Name: ejb30/sec/stateless/secpropagation
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/sec/stateless/secrunaspropagation
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -902,7 +906,7 @@ Stage Name: ejb30/tx
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/webservice/clientview
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -910,7 +914,7 @@ Stage Name: ejb30/webservice/clientview
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/webservice/interceptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -918,7 +922,7 @@ Stage Name: ejb30/webservice/interceptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb30/webservice/wscontext
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -934,7 +938,7 @@ Stage Name: ejb30/zombie
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: ejb32
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 704 tests.
@@ -1062,7 +1066,7 @@ Stage name: interop/csiv2/ew/ssl/sslr/upn/upid
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: interop/ejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 112 tests.
@@ -1070,7 +1074,7 @@ Stage Name: interop/ejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: interop/integration
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -1078,7 +1082,7 @@ Stage Name: interop/integration
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: interop/security
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 82 tests.
@@ -1086,7 +1090,7 @@ Stage Name: interop/security
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: interop/tx
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 46 tests.
@@ -1102,7 +1106,7 @@ Stage Name: j2eetools
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jacc
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 40 tests.
@@ -1110,7 +1114,7 @@ Stage Name: jacc
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaspic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 61 tests.
@@ -1134,7 +1138,7 @@ Stage Name: jaxrs/api/client
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/bindingpriority
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -1158,7 +1162,7 @@ Stage Name: jaxrs/api/rs/clienterrorexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/abstractmultivaluedmap
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -1166,7 +1170,7 @@ Stage Name: jaxrs/api/rs/core/abstractmultivaluedmap
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/cachecontrol
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -1174,7 +1178,7 @@ Stage Name: jaxrs/api/rs/core/cachecontrol
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/configurable
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -1182,7 +1186,7 @@ Stage Name: jaxrs/api/rs/core/configurable
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/configuration
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 17 tests.
@@ -1190,7 +1194,7 @@ Stage Name: jaxrs/api/rs/core/configuration
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/cookie
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 10 tests.
@@ -1198,7 +1202,7 @@ Stage Name: jaxrs/api/rs/core/cookie
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/entitytag
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -1206,7 +1210,7 @@ Stage Name: jaxrs/api/rs/core/entitytag
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/form
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -1214,7 +1218,7 @@ Stage Name: jaxrs/api/rs/core/form
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/genericentity
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 11 tests.
@@ -1222,7 +1226,7 @@ Stage Name: jaxrs/api/rs/core/genericentity
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/generictype
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 5 tests.
@@ -1230,7 +1234,7 @@ Stage Name: jaxrs/api/rs/core/generictype
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/link
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -1238,7 +1242,7 @@ Stage Name: jaxrs/api/rs/core/link
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/linkbuilder
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 29 tests.
@@ -1246,7 +1250,7 @@ Stage Name: jaxrs/api/rs/core/linkbuilder
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/linkjaxbadapter
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -1254,7 +1258,7 @@ Stage Name: jaxrs/api/rs/core/linkjaxbadapter
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/linkjaxblink
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -1262,7 +1266,7 @@ Stage Name: jaxrs/api/rs/core/linkjaxblink
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/mediatype
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 20 tests.
@@ -1270,7 +1274,7 @@ Stage Name: jaxrs/api/rs/core/mediatype
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/multivaluedhashmap
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 10 tests.
@@ -1278,7 +1282,7 @@ Stage Name: jaxrs/api/rs/core/multivaluedhashmap
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/multivaluedmap
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 17 tests.
@@ -1286,7 +1290,7 @@ Stage Name: jaxrs/api/rs/core/multivaluedmap
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/newcookie
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 31 tests.
@@ -1294,7 +1298,7 @@ Stage Name: jaxrs/api/rs/core/newcookie
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/nocontentexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -1302,7 +1306,7 @@ Stage Name: jaxrs/api/rs/core/nocontentexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/responsebuilder
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 15 tests.
@@ -1310,7 +1314,7 @@ Stage Name: jaxrs/api/rs/core/responsebuilder
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/responseclient
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 85 tests.
@@ -1318,7 +1322,7 @@ Stage Name: jaxrs/api/rs/core/responseclient
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/responsestatustype
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -1326,7 +1330,7 @@ Stage Name: jaxrs/api/rs/core/responsestatustype
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/uribuilder
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 125 tests.
@@ -1334,7 +1338,7 @@ Stage Name: jaxrs/api/rs/core/uribuilder
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/variant
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -1342,7 +1346,7 @@ Stage Name: jaxrs/api/rs/core/variant
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/core/variantlistbuilder
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -1350,7 +1354,7 @@ Stage Name: jaxrs/api/rs/core/variantlistbuilder
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/ext
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 38 tests.
@@ -1358,7 +1362,7 @@ Stage Name: jaxrs/api/rs/ext
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/forbiddenexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1366,7 +1370,7 @@ Stage Name: jaxrs/api/rs/forbiddenexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/internalservererrorexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1374,7 +1378,7 @@ Stage Name: jaxrs/api/rs/internalservererrorexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/notacceptableexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1382,7 +1386,7 @@ Stage Name: jaxrs/api/rs/notacceptableexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/notallowedexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 20 tests.
@@ -1390,7 +1394,7 @@ Stage Name: jaxrs/api/rs/notallowedexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/notauthorizedexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -1398,7 +1402,7 @@ Stage Name: jaxrs/api/rs/notauthorizedexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/notfoundexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1406,7 +1410,7 @@ Stage Name: jaxrs/api/rs/notfoundexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/notsupportedexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1414,7 +1418,7 @@ Stage Name: jaxrs/api/rs/notsupportedexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/processingexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 11 tests.
@@ -1422,7 +1426,7 @@ Stage Name: jaxrs/api/rs/processingexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/redirectexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -1430,7 +1434,7 @@ Stage Name: jaxrs/api/rs/redirectexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/runtimetype
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -1438,7 +1442,7 @@ Stage Name: jaxrs/api/rs/runtimetype
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/servererrorexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -1446,7 +1450,7 @@ Stage Name: jaxrs/api/rs/servererrorexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/serviceunavailableexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 18 tests.
@@ -1454,7 +1458,7 @@ Stage Name: jaxrs/api/rs/serviceunavailableexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/api/rs/webapplicationexceptiontest
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -1462,7 +1466,7 @@ Stage Name: jaxrs/api/rs/webapplicationexceptiontest
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/ee
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1174 tests.
@@ -1470,7 +1474,7 @@ Stage Name: jaxrs/ee
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/jaxrs21
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 184 tests.
@@ -1494,7 +1498,7 @@ Stage Name: jaxrs/servlet3
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jaxrs/spec
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 319 tests.
@@ -1510,7 +1514,7 @@ Stage Name: jbatch
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/batchUpdate
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 68 tests.
@@ -1518,7 +1522,7 @@ Stage Name: jdbc/ee/batchUpdate
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/callStmt
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1592 tests.
@@ -1526,7 +1530,7 @@ Stage Name: jdbc/ee/callStmt
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/connection
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 36 tests.
@@ -1534,7 +1538,7 @@ Stage Name: jdbc/ee/connection
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/dateTime
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 152 tests.
@@ -1542,7 +1546,7 @@ Stage Name: jdbc/ee/dateTime
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/dbMeta
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 940 tests.
@@ -1550,7 +1554,7 @@ Stage Name: jdbc/ee/dbMeta
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/escapeSyntax
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 324 tests.
@@ -1558,7 +1562,7 @@ Stage Name: jdbc/ee/escapeSyntax
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/exception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -1566,7 +1570,7 @@ Stage Name: jdbc/ee/exception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/prepStmt
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1084 tests.
@@ -1574,7 +1578,7 @@ Stage Name: jdbc/ee/prepStmt
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/resultSet
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 456 tests.
@@ -1582,7 +1586,7 @@ Stage Name: jdbc/ee/resultSet
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/rsMeta
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 84 tests.
@@ -1590,7 +1594,7 @@ Stage Name: jdbc/ee/rsMeta
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jdbc/ee/stmt
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 132 tests.
@@ -1606,7 +1610,7 @@ Stage Name: jms/core/appclient
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/bytesMsgQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1614,7 +1618,7 @@ Stage Name: jms/core/bytesMsgQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/bytesMsgTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1622,7 +1626,7 @@ Stage Name: jms/core/bytesMsgTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedQueueConnection
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 188 tests.
@@ -1630,7 +1634,7 @@ Stage Name: jms/core/closedQueueConnection
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedQueueReceiver
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -1638,7 +1642,7 @@ Stage Name: jms/core/closedQueueReceiver
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedQueueSender
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 64 tests.
@@ -1646,7 +1650,7 @@ Stage Name: jms/core/closedQueueSender
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedQueueSession
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 172 tests.
@@ -1654,7 +1658,7 @@ Stage Name: jms/core/closedQueueSession
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedTopicConnection
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 176 tests.
@@ -1662,7 +1666,7 @@ Stage Name: jms/core/closedTopicConnection
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedTopicPublisher
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -1670,7 +1674,7 @@ Stage Name: jms/core/closedTopicPublisher
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedTopicSession
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 168 tests.
@@ -1678,7 +1682,7 @@ Stage Name: jms/core/closedTopicSession
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/closedTopicSubscriber
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 28 tests.
@@ -1686,7 +1690,7 @@ Stage Name: jms/core/closedTopicSubscriber
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/exceptionQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 84 tests.
@@ -1694,7 +1698,7 @@ Stage Name: jms/core/exceptionQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/exceptiontests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 104 tests.
@@ -1710,7 +1714,7 @@ Stage Name: jms/core/exceptionTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/foreignMsgQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 44 tests.
@@ -1718,7 +1722,7 @@ Stage Name: jms/core/foreignMsgQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/foreignMsgTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 44 tests.
@@ -1726,7 +1730,7 @@ Stage Name: jms/core/foreignMsgTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/mapMsgQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -1734,7 +1738,7 @@ Stage Name: jms/core/mapMsgQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/mapMsgTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -1742,7 +1746,7 @@ Stage Name: jms/core/mapMsgTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/messageProducer
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -1750,7 +1754,7 @@ Stage Name: jms/core/messageProducer
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/messageQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -1758,7 +1762,7 @@ Stage Name: jms/core/messageQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/messageTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -1766,7 +1770,7 @@ Stage Name: jms/core/messageTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/objectMsgQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -1774,7 +1778,7 @@ Stage Name: jms/core/objectMsgQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/objectMsgTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -1782,7 +1786,7 @@ Stage Name: jms/core/objectMsgTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/queueConnection
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -1790,7 +1794,7 @@ Stage Name: jms/core/queueConnection
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/queueMsgHeaders
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 40 tests.
@@ -1798,7 +1802,7 @@ Stage Name: jms/core/queueMsgHeaders
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/queueMsgProperties
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1806,7 +1810,7 @@ Stage Name: jms/core/queueMsgProperties
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/queuetests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 52 tests.
@@ -1814,7 +1818,7 @@ Stage Name: jms/core/queuetests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/selectorQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 436 tests.
@@ -1822,7 +1826,7 @@ Stage Name: jms/core/selectorQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/selectorTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 72 tests.
@@ -1830,7 +1834,7 @@ Stage Name: jms/core/selectorTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/sessiontests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -1838,7 +1842,7 @@ Stage Name: jms/core/sessiontests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/streamMsgQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -1846,7 +1850,7 @@ Stage Name: jms/core/streamMsgQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/streamMsgTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -1854,7 +1858,7 @@ Stage Name: jms/core/streamMsgTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/topicConnection
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -1862,7 +1866,7 @@ Stage Name: jms/core/topicConnection
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/topicMsgHeaders
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 36 tests.
@@ -1870,7 +1874,7 @@ Stage Name: jms/core/topicMsgHeaders
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/topicMsgProperties
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -1878,7 +1882,7 @@ Stage Name: jms/core/topicMsgProperties
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core/topictests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 68 tests.
@@ -1894,7 +1898,7 @@ Stage Name: jms/core20/appclient
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/connectionfactorytests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -1902,7 +1906,7 @@ Stage Name: jms/core20/connectionfactorytests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/jmsconsumertests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 40 tests.
@@ -1910,7 +1914,7 @@ Stage Name: jms/core20/jmsconsumertests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/jmscontextqueuetests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 48 tests.
@@ -1918,7 +1922,7 @@ Stage Name: jms/core20/jmscontextqueuetests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/jmscontexttopictests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 96 tests.
@@ -1926,7 +1930,7 @@ Stage Name: jms/core20/jmscontexttopictests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/jmsproducerqueuetests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 120 tests.
@@ -1934,7 +1938,7 @@ Stage Name: jms/core20/jmsproducerqueuetests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/jmsproducertopictests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 120 tests.
@@ -1942,7 +1946,7 @@ Stage Name: jms/core20/jmsproducertopictests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/messageproducertests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 104 tests.
@@ -1950,7 +1954,7 @@ Stage Name: jms/core20/messageproducertests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/runtimeexceptiontests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 132 tests.
@@ -1958,7 +1962,7 @@ Stage Name: jms/core20/runtimeexceptiontests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/core20/sessiontests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 96 tests.
@@ -1981,7 +1985,7 @@ Stage Name: jms/ee/ejb/sessionQtests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/ejbweb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 30 tests.
@@ -1989,7 +1993,7 @@ Stage Name: jms/ee/ejbweb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_exceptQ
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 11 tests.
@@ -1997,7 +2001,7 @@ Stage Name: jms/ee/mdb/mdb_exceptQ
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_exceptT
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 11 tests.
@@ -2005,7 +2009,7 @@ Stage Name: jms/ee/mdb/mdb_exceptT
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgHdrQ
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 13 tests.
@@ -2013,7 +2017,7 @@ Stage Name: jms/ee/mdb/mdb_msgHdrQ
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgHdrT
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 13 tests.
@@ -2021,7 +2025,7 @@ Stage Name: jms/ee/mdb/mdb_msgHdrT
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgPropsQ
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -2029,7 +2033,7 @@ Stage Name: jms/ee/mdb/mdb_msgPropsQ
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgPropsT
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -2037,7 +2041,7 @@ Stage Name: jms/ee/mdb/mdb_msgPropsT
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgTypesQ1
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -2045,7 +2049,7 @@ Stage Name: jms/ee/mdb/mdb_msgTypesQ1
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgTypesQ2
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -2053,7 +2057,7 @@ Stage Name: jms/ee/mdb/mdb_msgTypesQ2
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgTypesQ3
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -2061,7 +2065,7 @@ Stage Name: jms/ee/mdb/mdb_msgTypesQ3
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgTypesT1
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -2069,7 +2073,7 @@ Stage Name: jms/ee/mdb/mdb_msgTypesT1
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgTypesT2
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -2077,7 +2081,7 @@ Stage Name: jms/ee/mdb/mdb_msgTypesT2
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_msgTypesT3
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -2085,7 +2089,7 @@ Stage Name: jms/ee/mdb/mdb_msgTypesT3
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_rec
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 10 tests.
@@ -2093,7 +2097,7 @@ Stage Name: jms/ee/mdb/mdb_rec
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_sndQ
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 5 tests.
@@ -2101,7 +2105,7 @@ Stage Name: jms/ee/mdb/mdb_sndQ
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_sndToQueue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 5 tests.
@@ -2109,7 +2113,7 @@ Stage Name: jms/ee/mdb/mdb_sndToQueue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_sndToTopic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 5 tests.
@@ -2117,7 +2121,7 @@ Stage Name: jms/ee/mdb/mdb_sndToTopic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/mdb_synchrec
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -2125,7 +2129,7 @@ Stage Name: jms/ee/mdb/mdb_synchrec
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee/mdb/xa
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 10 tests.
@@ -2141,7 +2145,7 @@ Stage Name: jms/ee20/cditests/ejbweb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/cditests/mdb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -2149,7 +2153,7 @@ Stage Name: jms/ee20/cditests/mdb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/cditests/usecases
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 10 tests.
@@ -2157,7 +2161,7 @@ Stage Name: jms/ee20/cditests/usecases
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/queue/selectorauto/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2165,7 +2169,7 @@ Stage Name: jms/ee20/ra/activationconfig/queue/selectorauto/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/queue/selectorauto/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2173,7 +2177,7 @@ Stage Name: jms/ee20/ra/activationconfig/queue/selectorauto/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/queue/selectordups/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2181,7 +2185,7 @@ Stage Name: jms/ee20/ra/activationconfig/queue/selectordups/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/queue/selectordups/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2189,7 +2193,7 @@ Stage Name: jms/ee20/ra/activationconfig/queue/selectordups/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/topic/noselnocidautodurable/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -2197,7 +2201,7 @@ Stage Name: jms/ee20/ra/activationconfig/topic/noselnocidautodurable/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/topic/noselnocidautodurable/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -2205,7 +2209,7 @@ Stage Name: jms/ee20/ra/activationconfig/topic/noselnocidautodurable/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/topic/selectorautociddurable/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2213,7 +2217,7 @@ Stage Name: jms/ee20/ra/activationconfig/topic/selectorautociddurable/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/topic/selectorautociddurable/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2221,7 +2225,7 @@ Stage Name: jms/ee20/ra/activationconfig/topic/selectorautociddurable/descriptor
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/topic/selectordupsnondurable/annotated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2229,7 +2233,7 @@ Stage Name: jms/ee20/ra/activationconfig/topic/selectordupsnondurable/annotated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jms/ee20/ra/activationconfig/topic/selectordupsnondurable/descriptor
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -2245,7 +2249,7 @@ Stage Name: jpa/core/annotations/access
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/assocoverride
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2253,7 +2257,7 @@ Stage Name: jpa/core/annotations/assocoverride
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/basic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 66 tests.
@@ -2261,7 +2265,7 @@ Stage Name: jpa/core/annotations/basic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/collectiontable
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2269,7 +2273,7 @@ Stage Name: jpa/core/annotations/collectiontable
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/convert
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -2277,7 +2281,7 @@ Stage Name: jpa/core/annotations/convert
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/discriminatorValue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -2285,7 +2289,7 @@ Stage Name: jpa/core/annotations/discriminatorValue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/elementcollection
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 18 tests.
@@ -2293,7 +2297,7 @@ Stage Name: jpa/core/annotations/elementcollection
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/embeddable
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2301,7 +2305,7 @@ Stage Name: jpa/core/annotations/embeddable
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/embeddableMapValue
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2309,7 +2313,7 @@ Stage Name: jpa/core/annotations/embeddableMapValue
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/entity
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -2317,7 +2321,7 @@ Stage Name: jpa/core/annotations/entity
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/id
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 84 tests.
@@ -2325,7 +2329,7 @@ Stage Name: jpa/core/annotations/id
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/lob
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2333,7 +2337,7 @@ Stage Name: jpa/core/annotations/lob
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/mapkey
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 36 tests.
@@ -2341,7 +2345,7 @@ Stage Name: jpa/core/annotations/mapkey
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/mapkeyclass
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2349,7 +2353,7 @@ Stage Name: jpa/core/annotations/mapkeyclass
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/mapkeycolumn
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -2357,7 +2361,7 @@ Stage Name: jpa/core/annotations/mapkeycolumn
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/mapkeyenumerated
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 22 tests.
@@ -2365,7 +2369,7 @@ Stage Name: jpa/core/annotations/mapkeyenumerated
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/mapkeyjoincolumn
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2373,7 +2377,7 @@ Stage Name: jpa/core/annotations/mapkeyjoincolumn
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/mapkeytemporal
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -2381,7 +2385,7 @@ Stage Name: jpa/core/annotations/mapkeytemporal
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/mapsid
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2389,7 +2393,7 @@ Stage Name: jpa/core/annotations/mapsid
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/nativequery
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 76 tests.
@@ -2397,7 +2401,7 @@ Stage Name: jpa/core/annotations/nativequery
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/onexmanyuni
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2405,7 +2409,7 @@ Stage Name: jpa/core/annotations/onexmanyuni
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/orderby
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 48 tests.
@@ -2413,7 +2417,7 @@ Stage Name: jpa/core/annotations/orderby
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/ordercolumn
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 18 tests.
@@ -2421,7 +2425,7 @@ Stage Name: jpa/core/annotations/ordercolumn
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/tableGenerator
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -2429,7 +2433,7 @@ Stage Name: jpa/core/annotations/tableGenerator
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/temporal
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 36 tests.
@@ -2437,7 +2441,7 @@ Stage Name: jpa/core/annotations/temporal
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/annotations/version
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 84 tests.
@@ -2445,7 +2449,7 @@ Stage Name: jpa/core/annotations/version
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/basic
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -2453,7 +2457,7 @@ Stage Name: jpa/core/basic
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/cache
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 20 tests.
@@ -2461,7 +2465,7 @@ Stage Name: jpa/core/cache
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/callback
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 396 tests.
@@ -2469,7 +2473,7 @@ Stage Name: jpa/core/callback
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/CriteriaBuilder
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 930 tests.
@@ -2477,7 +2481,7 @@ Stage Name: jpa/core/criteriaapi/CriteriaBuilder
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/CriteriaDelete
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 42 tests.
@@ -2485,7 +2489,7 @@ Stage Name: jpa/core/criteriaapi/CriteriaDelete
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/CriteriaQuery
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 228 tests.
@@ -2493,7 +2497,7 @@ Stage Name: jpa/core/criteriaapi/CriteriaQuery
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/CriteriaUpdate
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 60 tests.
@@ -2501,7 +2505,7 @@ Stage Name: jpa/core/criteriaapi/CriteriaUpdate
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/From
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 174 tests.
@@ -2509,7 +2513,7 @@ Stage Name: jpa/core/criteriaapi/From
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/Join
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 210 tests.
@@ -2525,7 +2529,7 @@ Stage Name: jpa/core/criteriaapi/metamodelquery
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/misc
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 204 tests.
@@ -2533,7 +2537,7 @@ Stage Name: jpa/core/criteriaapi/misc
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/parameter
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 48 tests.
@@ -2549,7 +2553,7 @@ Stage Name: jpa/core/criteriaapi/Root
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/criteriaapi/strquery
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 774 tests.
@@ -2557,7 +2561,7 @@ Stage Name: jpa/core/criteriaapi/strquery
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/derivedid
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 72 tests.
@@ -2573,7 +2577,7 @@ Stage Name: jpa/core/EntityGraph
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/entityManager
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 193 tests.
@@ -2581,7 +2585,7 @@ Stage Name: jpa/core/entityManager
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/entityManager2
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 132 tests.
@@ -2589,7 +2593,7 @@ Stage Name: jpa/core/entityManager2
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/entityManagerFactory
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 36 tests.
@@ -2597,7 +2601,7 @@ Stage Name: jpa/core/entityManagerFactory
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/entityManagerFactoryCloseExceptions.1
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2605,7 +2609,7 @@ Stage Name: jpa/core/entityManagerFactoryCloseExceptions.1
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/entitytest
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1000 tests.
@@ -2613,7 +2617,7 @@ Stage Name: jpa/core/entitytest
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/entitytest/detach/oneXone
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -2629,7 +2633,7 @@ Stage Name: jpa/core/entityTransaction
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/enums
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 317 tests.
@@ -2637,7 +2641,7 @@ Stage Name: jpa/core/enums
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/exceptions
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 34 tests.
@@ -2645,7 +2649,7 @@ Stage Name: jpa/core/exceptions
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/inheritance
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 60 tests.
@@ -2653,7 +2657,7 @@ Stage Name: jpa/core/inheritance
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/lock
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 34 tests.
@@ -2661,7 +2665,7 @@ Stage Name: jpa/core/lock
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/metamodelapi
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1554 tests.
@@ -2669,7 +2673,7 @@ Stage Name: jpa/core/metamodelapi
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/nestedembedding
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 18 tests.
@@ -2677,7 +2681,7 @@ Stage Name: jpa/core/nestedembedding
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/override.1
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 156 tests.
@@ -2685,7 +2689,7 @@ Stage Name: jpa/core/override.1
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/persistenceUtil
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2693,7 +2697,7 @@ Stage Name: jpa/core/persistenceUtil
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/persistenceUtilUtil
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 18 tests.
@@ -2701,7 +2705,7 @@ Stage Name: jpa/core/persistenceUtilUtil
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/query
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1220 tests.
@@ -2709,7 +2713,7 @@ Stage Name: jpa/core/query
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/relationship
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 198 tests.
@@ -2725,7 +2729,7 @@ Stage Name: jpa/core/StoredProcedureQuery
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/types
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 300 tests.
@@ -2733,7 +2737,7 @@ Stage Name: jpa/core/types
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/core/versioning
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 6 tests.
@@ -2741,7 +2745,7 @@ Stage Name: jpa/core/versioning
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jpa/ee
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 181 tests.
@@ -2765,7 +2769,7 @@ Stage Name: jsf/api/javax_faces/application
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/component
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4359 tests.
@@ -2773,7 +2777,7 @@ Stage Name: jsf/api/javax_faces/component
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/context
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 120 tests.
@@ -2781,7 +2785,7 @@ Stage Name: jsf/api/javax_faces/context
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/convert
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 124 tests.
@@ -2789,7 +2793,7 @@ Stage Name: jsf/api/javax_faces/convert
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/el
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 47 tests.
@@ -2797,7 +2801,7 @@ Stage Name: jsf/api/javax_faces/el
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/event
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 136 tests.
@@ -2805,7 +2809,7 @@ Stage Name: jsf/api/javax_faces/event
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/facesexception
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 5 tests.
@@ -2813,7 +2817,7 @@ Stage Name: jsf/api/javax_faces/facesexception
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/factoryfinder
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -2821,7 +2825,7 @@ Stage Name: jsf/api/javax_faces/factoryfinder
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/factoryfinderrelease
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -2829,7 +2833,7 @@ Stage Name: jsf/api/javax_faces/factoryfinderrelease
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/flow
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -2837,7 +2841,7 @@ Stage Name: jsf/api/javax_faces/flow
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/lifecycle
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -2845,7 +2849,7 @@ Stage Name: jsf/api/javax_faces/lifecycle
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/model
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 111 tests.
@@ -2853,7 +2857,7 @@ Stage Name: jsf/api/javax_faces/model
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/render
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -2861,7 +2865,7 @@ Stage Name: jsf/api/javax_faces/render
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/validator
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 66 tests.
@@ -2869,7 +2873,7 @@ Stage Name: jsf/api/javax_faces/validator
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/api/javax_faces/view
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 29 tests.
@@ -2877,7 +2881,7 @@ Stage Name: jsf/api/javax_faces/view
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/spec
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 221 tests.
@@ -2885,7 +2889,7 @@ Stage Name: jsf/spec
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsf/spec/flows
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 9 tests.
@@ -2901,7 +2905,7 @@ Stage Name: jsonb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/collectortests.1
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -2909,7 +2913,7 @@ Stage Name: jsonp/api/collectortests.1
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/exceptiontests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -2917,7 +2921,7 @@ Stage Name: jsonp/api/exceptiontests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonarraytests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 44 tests.
@@ -2925,7 +2929,7 @@ Stage Name: jsonp/api/jsonarraytests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonbuilderfactorytests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -2933,7 +2937,7 @@ Stage Name: jsonp/api/jsonbuilderfactorytests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsoncoding
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -2941,7 +2945,7 @@ Stage Name: jsonp/api/jsoncoding
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsongeneratorfactorytests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -2949,7 +2953,7 @@ Stage Name: jsonp/api/jsongeneratorfactorytests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsongeneratortests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 76 tests.
@@ -2957,7 +2961,7 @@ Stage Name: jsonp/api/jsongeneratortests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonnumbertests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -2965,7 +2969,7 @@ Stage Name: jsonp/api/jsonnumbertests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonobjecttests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -2973,7 +2977,7 @@ Stage Name: jsonp/api/jsonobjecttests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonparsereventtests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 8 tests.
@@ -2981,7 +2985,7 @@ Stage Name: jsonp/api/jsonparsereventtests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonparserfactorytests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 28 tests.
@@ -2989,7 +2993,7 @@ Stage Name: jsonp/api/jsonparserfactorytests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonparsertests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 88 tests.
@@ -2997,7 +3001,7 @@ Stage Name: jsonp/api/jsonparsertests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonreaderfactorytests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -3005,7 +3009,7 @@ Stage Name: jsonp/api/jsonreaderfactorytests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonreadertests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 116 tests.
@@ -3013,7 +3017,7 @@ Stage Name: jsonp/api/jsonreadertests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonstreamingtests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -3021,7 +3025,7 @@ Stage Name: jsonp/api/jsonstreamingtests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonstringtests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -3029,7 +3033,7 @@ Stage Name: jsonp/api/jsonstringtests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonvaluetests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 24 tests.
@@ -3037,7 +3041,7 @@ Stage Name: jsonp/api/jsonvaluetests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonwriterfactorytests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -3045,7 +3049,7 @@ Stage Name: jsonp/api/jsonwriterfactorytests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/jsonwritertests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 56 tests.
@@ -3053,7 +3057,7 @@ Stage Name: jsonp/api/jsonwritertests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/mergetests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 20 tests.
@@ -3061,7 +3065,7 @@ Stage Name: jsonp/api/mergetests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/patchtests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 32 tests.
@@ -3069,7 +3073,7 @@ Stage Name: jsonp/api/patchtests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/api/pointertests
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 16 tests.
@@ -3077,7 +3081,7 @@ Stage Name: jsonp/api/pointertests
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jsonp/pluggability
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 72 tests.
@@ -3093,7 +3097,7 @@ Stage Name: jsp
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jstl
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 541 tests.
@@ -3101,7 +3105,7 @@ Stage Name: jstl
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: jta
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 195 tests.
@@ -3109,7 +3113,7 @@ Stage Name: jta
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage name: rmiiiop
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 129 tests.
@@ -3117,7 +3121,7 @@ Stage name: rmiiiop
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: samples
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 13 tests.
@@ -3125,7 +3129,7 @@ Stage Name: samples
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: securityapi
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 84 tests.
@@ -3148,7 +3152,7 @@ Stage Name: servlet/api.1
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: servlet/compat
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -3156,7 +3160,7 @@ Stage Name: servlet/compat
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: servlet/ee/platform
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 18 tests.
@@ -3164,7 +3168,7 @@ Stage Name: servlet/ee/platform
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: servlet/ee/spec/crosscontext
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -3172,7 +3176,7 @@ Stage Name: servlet/ee/spec/crosscontext
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: servlet/ee/spec/security/permissiondd
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 14 tests.
@@ -3180,7 +3184,7 @@ Stage Name: servlet/ee/spec/security/permissiondd
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: servlet/ee/spec/security/runAs
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 2 tests.
@@ -3188,7 +3192,7 @@ Stage Name: servlet/ee/spec/security/runAs
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: servlet/pluggability
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 633 tests.
@@ -3196,7 +3200,7 @@ Stage Name: servlet/pluggability
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: servlet/spec
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 208 tests.
@@ -3220,7 +3224,7 @@ Stage Name: webservices12/deploy
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/ejb
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 40 tests.
@@ -3228,7 +3232,7 @@ Stage Name: webservices12/ejb
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/narrow
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -3236,7 +3240,7 @@ Stage Name: webservices12/narrow
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/sec/annotations/ejb/basicauth
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -3244,7 +3248,7 @@ Stage Name: webservices12/sec/annotations/ejb/basicauth
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/sec/annotations/ejb/basicauthssl
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 4 tests.
@@ -3252,7 +3256,7 @@ Stage Name: webservices12/sec/annotations/ejb/basicauthssl
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/sec/annotations/ejb/clientcert
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 3 tests.
@@ -3260,7 +3264,7 @@ Stage Name: webservices12/sec/annotations/ejb/clientcert
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/sec/descriptors/ejb/basicSSL
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -3268,7 +3272,7 @@ Stage Name: webservices12/sec/descriptors/ejb/basicSSL
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/sec/descriptors/ejb/certificate
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -3276,7 +3280,7 @@ Stage Name: webservices12/sec/descriptors/ejb/certificate
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/sec/descriptors/servlet/basicSSL
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 12 tests.
@@ -3284,7 +3288,7 @@ Stage Name: webservices12/sec/descriptors/servlet/basicSSL
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/sec/descriptors/servlet/certificate
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 1 tests.
@@ -3292,7 +3296,7 @@ Stage Name: webservices12/sec/descriptors/servlet/certificate
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/servlet
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 57 tests.
@@ -3300,7 +3304,7 @@ Stage Name: webservices12/servlet
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/specialcases
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 9 tests.
@@ -3308,7 +3312,7 @@ Stage Name: webservices12/specialcases
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices12/wsdlImport
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 92 tests.
@@ -3316,7 +3320,7 @@ Stage Name: webservices12/wsdlImport
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: webservices13
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 53 tests.
@@ -3324,7 +3328,7 @@ Stage Name: webservices13
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: websocket
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 745 tests.
@@ -3332,7 +3336,7 @@ Stage Name: websocket
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 [javatest.batch] ********************************************************************************
- 
+
 Stage Name: xa
 [javatest.batch] ********************************************************************************
 [javatest.batch] Completed running 66 tests.
@@ -3344,7 +3348,7 @@ Stage Name: xa
 
 Stage Name: Direct Injection TCK
 [INFO] Results:
-[INFO] 
+[INFO]
 [INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
 
 
@@ -3369,4 +3373,3 @@ Tests run: 1043, Failures: 0, Errors: 0, Skipped: 0
 
 
 ----
-

--- a/jakartaee/platform/8/TCKResults.adoc
+++ b/jakartaee/platform/8/TCKResults.adoc
@@ -18,8 +18,9 @@ https://jakarta.ee/specifications/platform/8[Jakarta EE Platform 8]
 http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8-eftl/staged-801/eclipse-jakartaeetck-8.0.1.zip[Jakarta EE Platform TCK 8.0.1],
 SHA-256: `3026f2b2fc7a2f1e802aed6cf1671d486dc90d1b03fd3519367577aa9f6545fa`
 
-* TCK Results Summary Below:
+* Public URL of TCK Results Summary:
 +
+link:TCKResults.html[TCK results summary]
 
 * Any Additional Specification Certification Requirements:
 +


### PR DESCRIPTION
Three items...
- Reinstate the self reference to TCKResults (required by process)
- Provide exact url for eventual Platform specification (it will be real on Monday or Tuesday)
- Provide reference for accepted JSF Signature challenge

And, it looks like Atom cleaned up some extra spaces on the various blank lines of the TCK Results.  I didn't change anything in this area, but you can see the minor change on all of the blank lines.