### PR TITLE
Add Java 8 to implementation runtimes tested

### DIFF
--- a/microprofile/restclient/2.0/TCKResults.adoc
+++ b/microprofile/restclient/2.0/TCKResults.adoc
@@ -19,7 +19,7 @@ link:TCKResults.html[TCK results summary]
 
 * Java runtime used to run the implementation:
 +
-Java 11
+Java 8 and 11
 
 * Summary of the information for the certification environment, operating system, cloud, ...:
 +


### PR DESCRIPTION
Emily mentioned that we need to certify on Java 8.  I re-ran the TCK using Java 8 and it passed.