### PR TITLE
TCK results for MicroProfile Context Propagation 1.2 RC1

### DIFF
--- a/microprofile/contextpropagation/1.2/TCKResults.adoc
+++ b/microprofile/contextpropagation/1.2/TCKResults.adoc
@@ -3,6 +3,427 @@
 
 As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Context Propagation 1.2.
 
+== Open Liberty 21.0.0.3-beta (wlp-1.0.49.cl210220210209-1100) MicroProfile Context Propagation 1.2 RC1 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2021-02-09_1100/openliberty-21.0.0.3-beta.zip[Open Liberty 21.0.0.3 Beta - 210220210209-1100]
+
+* Specification Name, Version and download URL:
++
+https://repo1.maven.org/maven2/org/eclipse/microprofile/context-propagation/microprofile-context-propagation-api/1.2-RC1/microprofile-context-propagation-api-1.2-RC1.jar[MicroProfile Context Propagation 1.2 RC 1]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+----
+java.version = 1.8.0_282
+java.runtime = OpenJDK Runtime Environment (1.8.0_282-b08)
+os = Mac OS X (10.15.7; x86_64) (en_US)
+
+java.version = 11.0.2
+java.runtime = OpenJDK Runtime Environment (11.0.2+9)
+os = Mac OS X (10.15.7; amd64) (en_US)
+----
+
+Test results:
+
+##### Java 8
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="1" name="ContextManagerTest" package="org.eclipse.microprofile.context.tck" tests="1" time="0.268" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.ContextManagerTest" name="builderForContextManagerIsProvided" time="0.268" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="2" name="MPConfigTest" package="org.eclipse.microprofile.context.tck" tests="7" time="0.454" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="defaultContextPropagationForManagedExecutorViaMPConfig" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="explicitlySpecifiedPropagatedTakesPrecedenceOverDefaults" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="beanInjected" time="0.305" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="defaultMaxAsyncAndMaxQueuedForManagedExecutorViaMPConfig" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="explicitlySpecifyAllAttributesOfThreadContext" time="0.022" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="defaultContextPropagationForThreadContextViaMPConfig" time="0.019" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="explicitlySpecifyMaxQueued5" time="0.027" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="3" name="ManagedExecutorTest" package="org.eclipse.microprofile.context.tck" tests="35" time="7.101" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="reuseManagedExecutorBuilder" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="shutdownNowPreventsAdditionalSubmitsAndCancelsTasks" time="0.042" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxQueuedInvalidValues" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="completedStageDependentStagesRunWithContext" time="0.031" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="completedFutureDependentStagesRunWithContext" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="untimedInvokeAnyRunsTasksWithContext" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="propagateApplicationContext" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="failedStageDependentStagesRunWithContext" time="0.069" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="failedFutureDependentStagesRunWithContext" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="timedInvokeAllRunsTasksWithContext" time="0.033" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="withDefaultExecutorServiceIsUsedDirectlyAndViaGetThreadContext" time="0.066" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="propagateTransactionContextJTA" time="0.074" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="timedInvokeAnyRunsTaskWithContext" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxQueued3" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxAsync2" time="5.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualRunnableOverridesContextOfManagedExecutor" time="0.036" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="clearUnspecifiedContexts" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualConsumerAndBiFunctionOverrideContextOfManagedExecutor" time="0.043" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="submittedTasksRunWithContext" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualFunctionOverridesContextOfManagedExecutor" time="0.036" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualCallableOverridesContextOfManagedExecutor" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="copyCompletionStage" time="0.025" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="builderForManagedExecutorIsProvided" time="0.052" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="executedTaskRunsWithContext" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="supplyAsyncStageAndDependentStagesRunWithContext" time="0.038" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="newIncompleteFutureDependentStagesRunWithContext" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="runAsyncStageAndDependentStagesRunWithContext" time="0.055" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="untimedInvokeAllRunsTasksWithContext" time="0.036" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxAsyncInvalidValues" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="shutdownPreventsAdditionalSubmits" time="0.535" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="copyCompletableFuture" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextControlsForManagedExecutorBuilder" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="executedTaskRunsWithClearedContext" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="threadContextHasSamePropagationSettings" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualSuppplierAndBiConsumerOverrideContextOfManagedExecutor" time="0.379" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="4" name="TckTest" package="org.eclipse.microprofile.context.tck" tests="1" time="0.350" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.TckTest" name="providerSet" time="0.350" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="5" name="ThreadContextTest" package="org.eclipse.microprofile.context.tck" tests="22" time="1.952" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualBiConsumerRunsWithContext" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="reuseThreadContextBuilder" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureDependentCompletionStagesRunWithContext" time="0.057" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextControlsForThreadContextBuilder" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureSwitchThreadContext" time="0.049" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withDefaultExecutorServiceContextCanInvokeAsyncActions" time="0.102" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="currentContextExecutorRunsWithContext" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="thirdPartyContextProvidersAreIncludedInThreadContext" time="0.043" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualCallableRunsWithContext" time="0.025" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualBiFunctionRunsWithContext" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="clearUnspecifiedContexts" time="0.814" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureMultipleThreadContexts" time="0.042" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="builderForThreadContextIsProvided" time="0.031" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="clearTransactionContextJTA" time="0.297" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureDependentCompletableFuturesRunWithContext" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureDependentStageForcedCompletion" time="0.089" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualSupplierRunsWithContext" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualConsumerRunsWithContext" time="0.041" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withoutDefaultExecutorServiceContextCannotInvokeAsyncActions" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="unchangedContextListDefaultsToEmpty" time="0.043" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualFunctionRunsWithContext" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualRunnableRunsWithContext" time="0.028" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="6" name="BasicCDITest" package="org.eclipse.microprofile.context.tck.cdi" tests="4" time="0.387" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="applicationDefinesProducerOfThreadContext" time="0.321" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="testBasicExecutorUsable" time="0.021" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="testVerifyInjection" time="0.020" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="applicationDefinesProducerUsingInjectedThreadContext" time="0.025" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="7" name="CDIContextTest" package="org.eclipse.microprofile.context.tck.cdi" tests="8" time="0.534" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDITCCtxPropagate" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxPropagatesRequestScopedBean" time="0.025" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxClearsConversationScopedBeans" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDITCCtxClear" time="0.342" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxClearsRequestScopedBean" time="0.022" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxPropagatesSessionScopedBean" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxPropagatesConversationScopedBean" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxClearsSessionScopedBeans" time="0.023" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="8" name="JTACDITest" package="org.eclipse.microprofile.context.tck.cdi" tests="6" time="0.625" timestamp="19 Feb 2021 19:44:44 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testConcurrentTransactionPropagation" time="0.050" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testTransactionPropagation" time="0.055" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testAsyncTransaction" time="0.400" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testRunWithTxnOfExecutingThread" time="0.023" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testTransactionWithUT" time="0.056" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testTransaction" time="0.041" />
+
+  </testsuite>
+</testsuites>
+
+
+----
+
+##### Java 11
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="1" name="ContextManagerTest" package="org.eclipse.microprofile.context.tck" tests="1" time="0.298" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.ContextManagerTest" name="builderForContextManagerIsProvided" time="0.298" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="2" name="MPConfigTest" package="org.eclipse.microprofile.context.tck" tests="7" time="0.448" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="explicitlySpecifiedPropagatedTakesPrecedenceOverDefaults" time="0.020" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="explicitlySpecifyMaxQueued5" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="beanInjected" time="0.313" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="defaultContextPropagationForManagedExecutorViaMPConfig" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="defaultMaxAsyncAndMaxQueuedForManagedExecutorViaMPConfig" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="defaultContextPropagationForThreadContextViaMPConfig" time="0.017" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.MPConfigTest" name="explicitlySpecifyAllAttributesOfThreadContext" time="0.017" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="3" name="ManagedExecutorTest" package="org.eclipse.microprofile.context.tck" tests="35" time="7.287" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="copyCompletionStage" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="supplyAsyncStageAndDependentStagesRunWithContext" time="0.044" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="builderForManagedExecutorIsProvided" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="copyCompletableFuture" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="withDefaultExecutorServiceIsUsedDirectlyAndViaGetThreadContext" time="0.062" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualRunnableOverridesContextOfManagedExecutor" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="runAsyncStageAndDependentStagesRunWithContext" time="0.068" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxQueued3" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="propagateTransactionContextJTA" time="0.070" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="failedFutureDependentStagesRunWithContext" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="timedInvokeAllRunsTasksWithContext" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="executedTaskRunsWithContext" time="0.031" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualCallableOverridesContextOfManagedExecutor" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="reuseManagedExecutorBuilder" time="0.036" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="timedInvokeAnyRunsTaskWithContext" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="newIncompleteFutureDependentStagesRunWithContext" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="executedTaskRunsWithClearedContext" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="submittedTasksRunWithContext" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="shutdownPreventsAdditionalSubmits" time="0.542" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="propagateApplicationContext" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualConsumerAndBiFunctionOverrideContextOfManagedExecutor" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="completedFutureDependentStagesRunWithContext" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxAsync2" time="5.051" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="failedStageDependentStagesRunWithContext" time="0.069" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="threadContextHasSamePropagationSettings" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="untimedInvokeAllRunsTasksWithContext" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxQueuedInvalidValues" time="0.041" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="shutdownNowPreventsAdditionalSubmitsAndCancelsTasks" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="completedStageDependentStagesRunWithContext" time="0.041" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="maxAsyncInvalidValues" time="0.050" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualFunctionOverridesContextOfManagedExecutor" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextOfContextualSuppplierAndBiConsumerOverrideContextOfManagedExecutor" time="0.424" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="untimedInvokeAnyRunsTasksWithContext" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="contextControlsForManagedExecutorBuilder" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ManagedExecutorTest" name="clearUnspecifiedContexts" time="0.030" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="4" name="TckTest" package="org.eclipse.microprofile.context.tck" tests="1" time="0.324" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.TckTest" name="providerSet" time="0.324" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="5" name="ThreadContextTest" package="org.eclipse.microprofile.context.tck" tests="22" time="2.141" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualSupplierRunsWithContext" time="0.053" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="currentContextExecutorRunsWithContext" time="0.043" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureDependentCompletionStagesRunWithContext" time="0.072" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualCallableRunsWithContext" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="builderForThreadContextIsProvided" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="clearUnspecifiedContexts" time="0.886" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualConsumerRunsWithContext" time="0.054" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextControlsForThreadContextBuilder" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withDefaultExecutorServiceContextCanInvokeAsyncActions" time="0.134" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureMultipleThreadContexts" time="0.051" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualRunnableRunsWithContext" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withoutDefaultExecutorServiceContextCannotInvokeAsyncActions" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="reuseThreadContextBuilder" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureDependentStageForcedCompletion" time="0.134" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualBiConsumerRunsWithContext" time="0.033" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualBiFunctionRunsWithContext" time="0.041" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="contextualFunctionRunsWithContext" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureDependentCompletableFuturesRunWithContext" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="thirdPartyContextProvidersAreIncludedInThreadContext" time="0.046" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="unchangedContextListDefaultsToEmpty" time="0.052" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="clearTransactionContextJTA" time="0.206" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.ThreadContextTest" name="withContextCaptureSwitchThreadContext" time="0.061" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="6" name="BasicCDITest" package="org.eclipse.microprofile.context.tck.cdi" tests="4" time="0.380" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="testBasicExecutorUsable" time="0.020" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="applicationDefinesProducerOfThreadContext" time="0.317" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="testVerifyInjection" time="0.017" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.BasicCDITest" name="applicationDefinesProducerUsingInjectedThreadContext" time="0.026" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="7" name="CDIContextTest" package="org.eclipse.microprofile.context.tck.cdi" tests="8" time="0.490" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxClearsSessionScopedBeans" time="0.017" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxPropagatesRequestScopedBean" time="0.019" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxClearsRequestScopedBean" time="0.017" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxPropagatesConversationScopedBean" time="0.021" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDITCCtxPropagate" time="0.019" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxPropagatesSessionScopedBean" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDIMECtxClearsConversationScopedBeans" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.CDIContextTest" name="testCDITCCtxClear" time="0.338" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Nathans-MacBook-Pro.local" id="8" name="JTACDITest" package="org.eclipse.microprofile.context.tck.cdi" tests="6" time="0.643" timestamp="19 Feb 2021 19:48:46 GMT">
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testTransactionWithUT" time="0.056" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testTransaction" time="0.055" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testTransactionPropagation" time="0.058" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testRunWithTxnOfExecutingThread" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testAsyncTransaction" time="0.396" />
+
+      <testcase classname="org.eclipse.microprofile.context.tck.cdi.JTACDITest" name="testConcurrentTransactionPropagation" time="0.054" />
+
+  </testsuite>
+</testsuites>
+
+
+----
+
+
 == Open Liberty TCK build - 202102051432-1214 MicroProfile Context Propagation 1.2 Certification Summary
 
 * Product Name, Version and download URL (if applicable):


### PR DESCRIPTION
Add TCK results for the release candidate, which is otherwise identical to the proposed final release, but unlike the currently-staged proposed final release, the release candidate is in an official Liberty image (21.0.0.3 Beta).