### PR TITLE
Update MP JWT 1.2 TCK results

### DIFF
--- a/microprofile/4.1/mpjwt/1.2/TCKResults.adoc
+++ b/microprofile/4.1/mpjwt/1.2/TCKResults.adoc
@@ -3,11 +3,11 @@
 
 As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Interoperable JWT RBAC 1.2.
 
-== Open Liberty 21.0.0.3 - MicroProfile Interoperable JWT RBAC 1.2 Certification Summary
+== Open Liberty 21.0.0.8-beta - MicroProfile Interoperable JWT RBAC 1.2 Certification Summary
 
 * Product Name, Version and download URL (if applicable):
 +
-https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/21.0.0.3/openliberty-runtime-21.0.0.3.zip[Open Liberty 21.0.0.3]
+https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/4.1/mpjwt/1.2/TCKResults.adoc
+++ b/microprofile/4.1/mpjwt/1.2/TCKResults.adoc
@@ -29,488 +29,488 @@ Java 8 Test results:
 
 [source,xml]
 ----
-
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="0" name="FATSuite" package="com.ibm.ws.microprofile.mpjwt12.tck" tests="6" time="459.525" timestamp="2021-03-17T10:09:32">
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="0" name="FATSuite" package="com.ibm.ws.microprofile.mpjwt12.tck" tests="6" time="466.366" timestamp="2021-07-03T07:24:51">
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_env" name="launchMpjwt12TCKLauncher_aud_env" time="190.423" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_env" name="launchMpjwt12TCKLauncher_aud_env" time="188.411" />
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv" name="launchMpjwt12TCKLauncher_aud_noenv" time="95.437" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv" name="launchMpjwt12TCKLauncher_aud_noenv" time="95.601" />
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_env" name="launchMpjwt12TCKLauncher_noaud_env" time="33.228" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_env" name="launchMpjwt12TCKLauncher_noaud_env" time="35.633" />
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_noenv" name="launchMpjwt12TCKLauncher_noaud_noenv" time="39.984" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_noenv" name="launchMpjwt12TCKLauncher_noaud_noenv" time="41.235" />
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv2" name="launchMpjwt12TCKLauncher_aud_noenv2" time="20.686" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv2" name="launchMpjwt12TCKLauncher_aud_noenv2" time="23.461" />
 
       <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.DummyForQuarantine" name="alwaysPass" time="0.001" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="1" name="ECPublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.478" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.478" />
+      <system-err />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="2" name="ECPublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.304" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="0.304" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="1" name="ECPublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.392" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.392" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="3" name="ECPublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.317" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" name="testKeyAsPEM" time="0.317" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="2" name="ECPublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.206" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="0.206" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="4" name="IssValidationFailTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="2.442" timestamp="17 Mar 2021 10:16:32 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" name="testNotRequiredIssMismatchFailure" time="2.442" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="3" name="ECPublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.259" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" name="testKeyAsPEM" time="0.259" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="5" name="IssValidationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="1.261" timestamp="17 Mar 2021 10:15:36 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" name="testRequiredIss" time="1.261" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="4" name="IssValidationFailTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="4.428" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" name="testNotRequiredIssMismatchFailure" time="4.428" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="6" name="PublicKeyAsBase64JWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.436" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" name="testKeyAsBase64JWK" time="0.436" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="5" name="IssValidationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="2.492" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" name="testRequiredIss" time="2.492" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="7" name="PublicKeyAsFileLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.356" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" name="testKeyAsLocationUrl" time="0.356" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="6" name="PublicKeyAsBase64JWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.352" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" name="testKeyAsBase64JWK" time="0.352" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="8" name="PublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.423" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.423" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="7" name="PublicKeyAsFileLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.343" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" name="testKeyAsLocationUrl" time="0.343" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="9" name="PublicKeyAsJWKLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="4.650" timestamp="17 Mar 2021 10:17:08 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="validateLocationUrlContents" time="1.725" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="testKeyAsLocationUrl" time="2.925" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="8" name="PublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.389" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.389" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="10" name="PublicKeyAsJWKSLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.335" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" name="testKeyAsLocation" time="0.335" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="9" name="PublicKeyAsJWKLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="6.846" timestamp="3 Jul 2021 07:32:33 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="validateLocationUrlContents" time="3.245" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="testKeyAsLocationUrl" time="3.601" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="11" name="PublicKeyAsJWKSTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.406" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" name="testKeyAsJWKS" time="0.406" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="10" name="PublicKeyAsJWKSLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.529" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" name="testKeyAsLocation" time="0.529" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="12" name="PublicKeyAsJWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.500" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" name="testKeyAsJWK" time="0.500" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="11" name="PublicKeyAsJWKSTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.364" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" name="testKeyAsJWKS" time="0.364" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="13" name="PublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="3.824" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="3.824" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="12" name="PublicKeyAsJWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.392" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" name="testKeyAsJWK" time="0.392" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="14" name="PublicKeyAsPEMLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.848" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="validateLocationUrlContents" time="0.247" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="testKeyAsLocationUrl" time="0.601" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="13" name="PublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="6.552" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="6.552" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="15" name="PublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.439" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" name="testKeyAsPEM" time="0.439" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="14" name="PublicKeyAsPEMLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.726" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="testKeyAsLocationUrl" time="0.480" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="validateLocationUrlContents" time="0.246" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="16" name="TokenAsCookieIgnoredTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.490" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="noTokenHeaderSetToCookie" time="0.248" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="validJwt" time="0.242" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="15" name="PublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.402" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" name="testKeyAsPEM" time="0.402" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="17" name="TokenAsCookieTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.255" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" name="validJwt" time="0.255" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="16" name="TokenAsCookieIgnoredTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.523" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="noTokenHeaderSetToCookie" time="0.309" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="validJwt" time="0.214" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="18" name="PrivateKeyAsJWKClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.351" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" name="testKeyAsLocation" time="0.351" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="17" name="TokenAsCookieTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.274" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" name="validJwt" time="0.274" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="19" name="PrivateKeyAsJWKSClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.351" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" name="testKeyAsLocation" time="0.351" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="18" name="PrivateKeyAsJWKClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.370" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" name="testKeyAsLocation" time="0.370" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="20" name="PrivateKeyAsPEMClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.447" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" name="testKeyAsLocationResource" time="0.447" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="19" name="PrivateKeyAsJWKSClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.443" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" name="testKeyAsLocation" time="0.443" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="21" name="ApplicationScopedInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.811" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenJwt" time="0.224" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenClaimValue" time="0.202" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawToken1Provider" time="0.385" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="20" name="PrivateKeyAsPEMClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.453" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" name="testKeyAsLocationResource" time="0.453" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="22" name="AudArrayValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="1.030" timestamp="17 Mar 2021 10:16:32 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" name="testRequiredAudMatch" time="1.030" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="21" name="ApplicationScopedInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.839" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenClaimValue" time="0.230" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawToken1Provider" time="0.360" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenJwt" time="0.249" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="23" name="AudValidationBadAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.207" timestamp="17 Mar 2021 10:16:32 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" name="testRequiredAudMismatchFailure" time="0.207" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="22" name="AudArrayValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="1.619" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" name="testRequiredAudMatch" time="1.619" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="24" name="AudValidationMissingAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.242" timestamp="17 Mar 2021 10:16:32 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" name="testRequiredAudMissingFailure" time="0.242" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="23" name="AudValidationBadAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.180" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" name="testRequiredAudMismatchFailure" time="0.180" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="25" name="AudValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.425" timestamp="17 Mar 2021 10:16:32 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" name="testRequiredAudMatch" time="0.425" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="24" name="AudValidationMissingAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.192" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" name="testRequiredAudMissingFailure" time="0.192" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="26" name="ClaimValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="19" time="6.386" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomDouble" time="0.194" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="25" name="AudValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.373" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" name="testRequiredAudMatch" time="0.373" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTI" time="0.138" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="26" name="ClaimValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="19" time="8.188" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalSubject" time="0.182" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAuthTimeStandard" time="0.209" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTIStandard" time="0.154" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedSubjectStandard" time="0.172" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.142" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudience" time="5.340" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudienceStandard" time="0.179" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomDouble" time="0.156" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomInteger" time="0.167" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAt" time="0.156" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomBoolean" time="0.166" />
 
       <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomString" time="0.169" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerClaim" time="0.154" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawToken" time="0.149" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTIStandard" time="0.126" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.161" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerStandardClaim" time="0.160" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedSubjectStandard" time="0.128" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomBoolean" time="0.170" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAuthTimeStandard" time="0.178" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAtStandard" time="0.169" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawTokenStandard" time="0.149" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalSubject" time="0.145" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerClaim" time="0.152" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawTokenStandard" time="0.158" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAtStandard" time="0.160" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.172" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerStandardClaim" time="0.141" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudienceStandard" time="0.215" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAt" time="0.173" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.172" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomInteger" time="0.189" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudience" time="3.328" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawToken" time="0.173" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTI" time="0.159" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="27" name="CookieTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="5" time="0.834" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="wrongCookieName" time="0.097" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="27" name="CookieTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="5" time="0.739" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="expiredCookie" time="0.127" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="validCookieJwt" time="0.275" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="ignoreHeaderIfCookieSet" time="0.163" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="ignoreHeaderIfCookieSet" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="emptyCookie" time="0.063" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="emptyCookie" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="wrongCookieName" time="0.121" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="expiredCookie" time="0.203" />
-
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="28" name="EmptyTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.336" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="emptyToken" time="0.099" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="validToken" time="0.170" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="invalidToken" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="validCookieJwt" time="0.265" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="29" name="InvalidTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="4" time="0.983" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoExpiredToken" time="0.117" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="28" name="EmptyTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.439" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="invalidToken" time="0.116" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSigner" time="0.527" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="emptyToken" time="0.117" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSignerAlg" time="0.072" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadIssuer" time="0.267" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="validToken" time="0.206" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="30" name="JsonValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.209" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken" time="0.117" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="29" name="InvalidTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="4" time="1.126" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadIssuer" time="0.300" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience2" time="0.185" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSigner" time="0.567" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomIntegerArray" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSignerAlg" time="0.143" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI" time="0.128" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble" time="0.160" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim2" time="0.138" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger" time="0.143" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt" time="0.115" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomStringArray" time="0.125" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI2" time="0.135" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString2" time="0.132" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger2" time="0.135" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString" time="0.107" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble2" time="0.189" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience" time="0.282" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt2" time="0.208" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim" time="0.099" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime" time="0.187" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDoubleArray" time="0.134" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime2" time="0.248" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken2" time="0.127" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoExpiredToken" time="0.116" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="31" name="PrimitiveInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="1.328" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedSUB" time="0.096" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="30" name="JsonValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.428" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime" time="0.149" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedGroups" time="0.110" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble" time="0.144" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedExpiration" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDoubleArray" time="0.163" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomBoolean" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString" time="0.121" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomString" time="0.140" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString2" time="0.163" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedRawToken" time="0.116" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger2" time="0.163" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyIssuerClaim" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken" time="0.149" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedUPN" time="0.110" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomStringArray" time="0.133" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedAudience" time="0.187" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomIntegerArray" time="0.124" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedIssuedAt" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience" time="0.270" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedJTI" time="0.135" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience2" time="0.229" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="32" name="PrincipalInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.251" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" name="verifyInjectedPrincipal" time="0.251" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime2" time="0.192" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="33" name="ProviderInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="2.426" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience2" time="0.141" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt" time="0.138" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim" time="0.137" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble2" time="0.208" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken2" time="0.175" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim2" time="0.152" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble" time="0.103" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI2" time="0.188" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject2" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI" time="0.123" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience" time="0.238" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger" time="0.137" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken2" time="0.101" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI2" time="0.106" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString2" time="0.166" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.104" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger" time="0.118" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble2" time="0.124" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString" time="0.098" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim" time="0.128" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim2" time="0.117" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime2" time="0.095" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt2" time="0.102" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger2" time="0.118" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt2" time="0.170" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="34" name="RequiredClaimsTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="2.004" timestamp="17 Mar 2021 10:15:36 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyExpiration" time="0.183" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="31" name="PrimitiveInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="1.357" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyIssuerClaim" time="0.125" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuedAt" time="0.204" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedJTI" time="0.100" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuerClaim" time="0.189" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedGroups" time="0.100" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifySubClaim" time="0.150" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedUPN" time="0.114" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyUPN" time="0.110" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedExpiration" time="0.095" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyOptionalAudience" time="0.165" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomString" time="0.104" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithIatOlderThanExp" time="0.187" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedAudience" time="0.277" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyAudience" time="0.299" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomBoolean" time="0.124" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyJTI" time="0.213" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedIssuedAt" time="0.098" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutName" time="0.152" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedSUB" time="0.105" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutExpiration" time="0.152" />
-
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="35" name="RolesAllowedTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="15" time="1.370" timestamp="17 Mar 2021 10:12:56 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getPrincipalClass" time="0.104" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoWithToken2" time="0.111" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoBASIC" time="0.044" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoGroups" time="0.112" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignEncryptToken" time="0.090" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getInjectedPrincipal" time="0.072" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoNeedsToken2Role" time="0.091" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callHeartbeat" time="0.035" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="noTokenHeaderSetToCookie" time="0.089" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRole" time="0.139" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignToken" time="0.084" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoAuth" time="0.036" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho2" time="0.085" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRoleToken2" time="0.096" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho" time="0.182" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedRawToken" time="0.115" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="36" name="RsaKeySignatureTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.230" timestamp="17 Mar 2021 10:14:47 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" name="callEcho" time="0.230" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="32" name="PrincipalInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.298" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" name="verifyInjectedPrincipal" time="0.298" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="37" name="UnsecuredPingTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="2.335" timestamp="17 Mar 2021 10:15:36 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" name="callEchoNoAuth" time="2.335" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="33" name="ProviderInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="2.784" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim" time="0.136" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble" time="0.183" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.109" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger2" time="0.146" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim2" time="0.159" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt2" time="0.125" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject" time="0.105" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt" time="0.122" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime2" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble2" time="0.114" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience2" time="0.133" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString2" time="0.112" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI" time="0.116" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.140" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken2" time="0.107" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString" time="0.130" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI2" time="0.153" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger" time="0.116" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject2" time="0.105" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience" time="0.222" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="38" name="RolesAllowedSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe" tests="14" time="1.892" timestamp="17 Mar 2021 10:12:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getInjectedPrincipal" time="0.101" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="34" name="RequiredClaimsTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="2.310" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuedAt" time="0.167" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho" time="0.309" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyOptionalAudience" time="0.332" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho2" time="0.164" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyJTI" time="0.177" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignToken" time="0.150" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithIatOlderThanExp" time="0.260" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callHeartbeat" time="0.026" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyUPN" time="0.131" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRoleToken2" time="0.200" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifySubClaim" time="0.200" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoBASIC" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutExpiration" time="0.162" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoWithToken2" time="0.181" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutName" time="0.204" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignEncryptToken" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyExpiration" time="0.191" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoWithoutCty" time="0.163" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyAudience" time="0.257" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getPrincipalClass" time="0.142" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuerClaim" time="0.229" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="35" name="RolesAllowedTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="15" time="1.597" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho2" time="0.137" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoGroups" time="0.122" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRoleToken2" time="0.136" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoAuth" time="0.054" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoNeedsToken2Role" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getInjectedPrincipal" time="0.093" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="noTokenHeaderSetToCookie" time="0.111" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho" time="0.205" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignToken" time="0.090" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoWithToken2" time="0.114" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callHeartbeat" time="0.049" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignEncryptToken" time="0.074" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRole" time="0.133" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getPrincipalClass" time="0.102" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoBASIC" time="0.051" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="36" name="RsaKeySignatureTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.295" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" name="callEcho" time="0.295" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="37" name="UnsecuredPingTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="3.956" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" name="callEchoNoAuth" time="3.956" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="38" name="RolesAllowedSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe" tests="14" time="2.187" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho" time="0.197" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignToken" time="0.158" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoNeedsToken2Role" time="0.265" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callHeartbeat" time="0.047" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoWithoutCty" time="0.232" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRoleToken2" time="0.393" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoWithToken2" time="0.304" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRole" time="0.110" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignEncryptToken" time="0.102" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho2" time="0.100" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoBASIC" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getPrincipalClass" time="0.099" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getInjectedPrincipal" time="0.114" />
 
       <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoNoAuth" time="0.034" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRole" time="0.072" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoNeedsToken2Role" time="0.193" />
-
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="39" name="TokenUtilsEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="8" time="1.114" timestamp="17 Mar 2021 10:16:32 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testExpGrace" time="0.060" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="39" name="TokenUtilsEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="8" time="1.147" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailAlgorithm" time="0.015" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidToken" time="0.020" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailExpired" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidateSignedToken" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailEncryption" time="0.970" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidToken" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testExpGrace" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailJustExpired" time="0.021" />
 
       <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailIssuer" time="0.021" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailAlgorithm" time="0.017" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="40" name="TokenUtilsSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="7" time="0.433" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptECSignedClaims" time="0.167" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidateSignedToken" time="0.019" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaims" time="0.068" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailExpired" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaimsWithoutCty" time="0.064" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailJustExpired" time="0.025" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateSignedToken" time="0.018" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailEncryption" time="0.921" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByRSKeyVerifiedByECKey" time="0.050" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByECKeyVerifiedByRSKey" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateEncryptedOnlyToken" time="0.026" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="40" name="TokenUtilsSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="7" time="0.642" timestamp="17 Mar 2021 10:16:32 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptECSignedClaims" time="0.212" />
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="41" name="TokenUtilsTest" package="org.eclipse.microprofile.jwt.tck.util" tests="18" time="2.614" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken" time="0.032" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaimsWithoutCty" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByECKeyVerifiedByRSKey" time="0.132" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByRSKeyVerifiedByECKey" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignature" time="0.413" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateEncryptedOnlyToken" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGrace" time="0.855" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByECKeyVerifiedByRSKey" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenDeprecated" time="0.021" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaims" time="0.117" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithmDeprecated" time="0.007" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateSignedToken" time="0.022" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpired" time="0.045" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprs2359mcddiz1-n.fyre.ibm.com" id="41" name="TokenUtilsTest" package="org.eclipse.microprofile.jwt.tck.util" tests="18" time="3.528" timestamp="17 Mar 2021 10:15:36 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGraceDeprecated" time="0.024" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuerDeprecated" time="0.028" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenEC256" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuer" time="0.028" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithm" time="0.012" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpired" time="0.025" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpired" time="0.018" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken1024BitKeyLength" time="0.056" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken1024BitKeyLength" time="0.372" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpiredDeprecated" time="0.027" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpiredDeprecated" time="0.017" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignatureDeprecated" time="0.818" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGrace" time="0.912" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpiredDeprecated" time="0.020" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithmDeprecated" time="0.005" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenEC256" time="0.034" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignature" time="1.534" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByRSKeyVerifiedByECKey" time="0.030" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuer" time="0.017" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithm" time="0.016" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpired" time="0.039" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByECKeyVerifiedByRSKey" time="0.080" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenDeprecated" time="0.019" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByRSKeyVerifiedByECKey" time="0.020" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuerDeprecated" time="0.019" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken" time="0.019" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpiredDeprecated" time="0.017" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignatureDeprecated" time="0.366" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGraceDeprecated" time="0.027" />
 
   </testsuite>
 </testsuites>
-
 ----
 
 Java 11 Test results:
@@ -519,481 +519,484 @@ Java 11 Test results:
 ----
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="0" name="FATSuite" package="com.ibm.ws.microprofile.mpjwt12.tck" tests="6" time="607.635" timestamp="2021-03-17T08:56:33">
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_env" name="launchMpjwt12TCKLauncher_aud_env" time="314.0" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="0" name="FATSuite" package="com.ibm.ws.microprofile.mpjwt12.tck" tests="6" time="648.411" timestamp="2021-07-03T07:37:45">
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv" name="launchMpjwt12TCKLauncher_aud_noenv" time="94.583" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_env" name="launchMpjwt12TCKLauncher_aud_env" time="353.26" />
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_env" name="launchMpjwt12TCKLauncher_noaud_env" time="35.457" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv" name="launchMpjwt12TCKLauncher_aud_noenv" time="95.514" />
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_noenv" name="launchMpjwt12TCKLauncher_noaud_noenv" time="41.587" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_env" name="launchMpjwt12TCKLauncher_noaud_env" time="34.981" />
 
-      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv2" name="launchMpjwt12TCKLauncher_aud_noenv2" time="23.884" />
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_noenv" name="launchMpjwt12TCKLauncher_noaud_noenv" time="40.157" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv2" name="launchMpjwt12TCKLauncher_aud_noenv2" time="22.108" />
 
       <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.DummyForQuarantine" name="alwaysPass" time="0.001" />
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="1" name="ECPublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.397" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.397" />
+
+      <system-err><![CDATA[]]></system-err>
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="2" name="ECPublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.288" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="0.288" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="1" name="ECPublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.479" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.479" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="3" name="ECPublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.278" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" name="testKeyAsPEM" time="0.278" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="2" name="ECPublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.391" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="0.391" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="4" name="IssValidationFailTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="5.395" timestamp="17 Mar 2021 09:05:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" name="testNotRequiredIssMismatchFailure" time="5.395" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="3" name="ECPublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.293" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" name="testKeyAsPEM" time="0.293" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="5" name="IssValidationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="3.356" timestamp="17 Mar 2021 09:04:54 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" name="testRequiredIss" time="3.356" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="4" name="IssValidationFailTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="5.808" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" name="testNotRequiredIssMismatchFailure" time="5.808" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="6" name="PublicKeyAsBase64JWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.260" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" name="testKeyAsBase64JWK" time="0.260" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="5" name="IssValidationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="3.086" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" name="testRequiredIss" time="3.086" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="7" name="PublicKeyAsFileLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.359" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" name="testKeyAsLocationUrl" time="0.359" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="6" name="PublicKeyAsBase64JWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.332" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" name="testKeyAsBase64JWK" time="0.332" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="8" name="PublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.370" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.370" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="7" name="PublicKeyAsFileLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.363" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" name="testKeyAsLocationUrl" time="0.363" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="9" name="PublicKeyAsJWKLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="8.492" timestamp="17 Mar 2021 09:06:38 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="testKeyAsLocationUrl" time="3.601" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="validateLocationUrlContents" time="4.891" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="8" name="PublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.334" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.334" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="10" name="PublicKeyAsJWKSLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.398" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" name="testKeyAsLocation" time="0.398" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="9" name="PublicKeyAsJWKLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="7.698" timestamp="3 Jul 2021 07:48:29 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="validateLocationUrlContents" time="4.391" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="testKeyAsLocationUrl" time="3.307" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="11" name="PublicKeyAsJWKSTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.444" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" name="testKeyAsJWKS" time="0.444" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="10" name="PublicKeyAsJWKSLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.530" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" name="testKeyAsLocation" time="0.530" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="12" name="PublicKeyAsJWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.337" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" name="testKeyAsJWK" time="0.337" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="11" name="PublicKeyAsJWKSTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.348" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" name="testKeyAsJWKS" time="0.348" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="13" name="PublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="7.120" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="7.120" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="12" name="PublicKeyAsJWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.393" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" name="testKeyAsJWK" time="0.393" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="14" name="PublicKeyAsPEMLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.986" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="validateLocationUrlContents" time="0.314" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="testKeyAsLocationUrl" time="0.672" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="13" name="PublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="7.246" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="7.246" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="15" name="PublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.358" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" name="testKeyAsPEM" time="0.358" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="14" name="PublicKeyAsPEMLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="1.091" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="validateLocationUrlContents" time="0.296" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="testKeyAsLocationUrl" time="0.795" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="16" name="TokenAsCookieIgnoredTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.786" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="noTokenHeaderSetToCookie" time="0.464" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="validJwt" time="0.322" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="15" name="PublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.476" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" name="testKeyAsPEM" time="0.476" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="17" name="TokenAsCookieTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.292" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" name="validJwt" time="0.292" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="16" name="TokenAsCookieIgnoredTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.642" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="noTokenHeaderSetToCookie" time="0.418" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="validJwt" time="0.224" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="18" name="PrivateKeyAsJWKClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.392" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" name="testKeyAsLocation" time="0.392" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="17" name="TokenAsCookieTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.340" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" name="validJwt" time="0.340" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="19" name="PrivateKeyAsJWKSClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.249" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" name="testKeyAsLocation" time="0.249" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="18" name="PrivateKeyAsJWKClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.281" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" name="testKeyAsLocation" time="0.281" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="20" name="PrivateKeyAsPEMClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.316" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" name="testKeyAsLocationResource" time="0.316" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="19" name="PrivateKeyAsJWKSClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.255" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" name="testKeyAsLocation" time="0.255" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="21" name="ApplicationScopedInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.871" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenJwt" time="0.231" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenClaimValue" time="0.242" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawToken1Provider" time="0.398" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="20" name="PrivateKeyAsPEMClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.274" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" name="testKeyAsLocationResource" time="0.274" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="22" name="AudArrayValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="2.206" timestamp="17 Mar 2021 09:05:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" name="testRequiredAudMatch" time="2.206" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="21" name="ApplicationScopedInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="1.025" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenClaimValue" time="0.244" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenJwt" time="0.253" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawToken1Provider" time="0.528" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="23" name="AudValidationBadAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.198" timestamp="17 Mar 2021 09:05:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" name="testRequiredAudMismatchFailure" time="0.198" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="22" name="AudArrayValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="2.210" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" name="testRequiredAudMatch" time="2.210" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="24" name="AudValidationMissingAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.194" timestamp="17 Mar 2021 09:05:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" name="testRequiredAudMissingFailure" time="0.194" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="23" name="AudValidationBadAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.160" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" name="testRequiredAudMismatchFailure" time="0.160" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="25" name="AudValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.366" timestamp="17 Mar 2021 09:05:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" name="testRequiredAudMatch" time="0.366" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="24" name="AudValidationMissingAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.261" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" name="testRequiredAudMissingFailure" time="0.261" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="26" name="ClaimValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="19" time="10.146" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.207" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomString" time="0.205" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudienceStandard" time="0.217" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerStandardClaim" time="0.152" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.138" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomInteger" time="0.177" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAuthTimeStandard" time="0.219" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTIStandard" time="0.156" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerClaim" time="0.135" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudience" time="7.041" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomBoolean" time="0.175" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTI" time="0.166" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalSubject" time="0.169" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomDouble" time="0.172" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawToken" time="0.147" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedSubjectStandard" time="0.143" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAt" time="0.165" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAtStandard" time="0.207" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawTokenStandard" time="0.155" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="25" name="AudValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.416" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" name="testRequiredAudMatch" time="0.416" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="27" name="CookieTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="5" time="0.688" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="ignoreHeaderIfCookieSet" time="0.203" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="26" name="ClaimValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="19" time="11.212" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAtStandard" time="0.261" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="emptyCookie" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudienceStandard" time="0.271" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="wrongCookieName" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTI" time="0.192" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="expiredCookie" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTIStandard" time="0.201" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="validCookieJwt" time="0.255" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomDouble" time="0.224" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="28" name="EmptyTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.464" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="emptyToken" time="0.159" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomString" time="0.191" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="invalidToken" time="0.146" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedSubjectStandard" time="0.197" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="validToken" time="0.159" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawToken" time="0.211" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="29" name="InvalidTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="4" time="1.372" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoExpiredToken" time="0.154" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAt" time="0.222" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSignerAlg" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomBoolean" time="0.218" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSigner" time="0.851" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerClaim" time="0.205" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadIssuer" time="0.273" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAuthTimeStandard" time="0.257" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="30" name="JsonValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.653" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime" time="0.187" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerStandardClaim" time="0.186" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble" time="0.166" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomInteger" time="0.207" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime2" time="0.223" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.166" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI2" time="0.160" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.183" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken2" time="0.156" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudience" time="7.393" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken" time="0.146" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawTokenStandard" time="0.206" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience2" time="0.210" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble2" time="0.226" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomStringArray" time="0.158" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDoubleArray" time="0.173" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger2" time="0.181" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString" time="0.130" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience" time="0.304" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim2" time="0.147" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim" time="0.140" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger" time="0.174" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI" time="0.172" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt2" time="0.147" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt" time="0.163" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomIntegerArray" time="0.155" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString2" time="0.135" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalSubject" time="0.221" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="31" name="PrimitiveInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="1.976" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomString" time="0.206" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="27" name="CookieTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="5" time="0.790" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="ignoreHeaderIfCookieSet" time="0.169" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedRawToken" time="0.126" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="emptyCookie" time="0.110" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedIssuedAt" time="0.107" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="wrongCookieName" time="0.084" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedAudience" time="0.389" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="validCookieJwt" time="0.316" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedJTI" time="0.130" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedSUB" time="0.209" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomBoolean" time="0.219" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedGroups" time="0.117" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedUPN" time="0.185" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyIssuerClaim" time="0.159" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedExpiration" time="0.129" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="expiredCookie" time="0.111" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="32" name="PrincipalInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.363" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" name="verifyInjectedPrincipal" time="0.363" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="28" name="EmptyTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.551" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="emptyToken" time="0.227" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="invalidToken" time="0.135" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="validToken" time="0.189" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="33" name="ProviderInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="2.605" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt" time="0.112" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="29" name="InvalidTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="4" time="1.521" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoExpiredToken" time="0.094" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadIssuer" time="0.349" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSignerAlg" time="0.108" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience2" time="0.112" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI" time="0.102" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger" time="0.124" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString" time="0.112" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject" time="0.106" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt2" time="0.123" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime2" time="0.107" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject2" time="0.103" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience" time="0.257" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble2" time="0.132" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble" time="0.111" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.124" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim2" time="0.158" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger2" time="0.120" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI2" time="0.106" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString2" time="0.128" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken2" time="0.112" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken" time="0.141" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSigner" time="0.970" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="34" name="RequiredClaimsTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="1.994" timestamp="17 Mar 2021 09:04:54 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuerClaim" time="0.223" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="30" name="JsonValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.814" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger2" time="0.173" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuedAt" time="0.151" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomIntegerArray" time="0.161" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyJTI" time="0.158" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI" time="0.149" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutName" time="0.167" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble2" time="0.198" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyAudience" time="0.375" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDoubleArray" time="0.229" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithIatOlderThanExp" time="0.263" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime" time="0.198" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyOptionalAudience" time="0.138" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim2" time="0.182" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyUPN" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken" time="0.152" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutExpiration" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString2" time="0.161" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifySubClaim" time="0.174" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger" time="0.180" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyExpiration" time="0.148" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim" time="0.162" />
 
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="35" name="RolesAllowedTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="15" time="1.776" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="noTokenHeaderSetToCookie" time="0.129" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime2" time="0.194" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRole" time="0.207" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken2" time="0.166" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRoleToken2" time="0.185" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomStringArray" time="0.142" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoGroups" time="0.122" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString" time="0.163" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getPrincipalClass" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI2" time="0.170" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callHeartbeat" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience2" time="0.183" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoAuth" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt" time="0.142" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoNeedsToken2Role" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt2" time="0.165" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoBASIC" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble" time="0.160" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho2" time="0.136" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getInjectedPrincipal" time="0.100" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignEncryptToken" time="0.050" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignToken" time="0.072" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoWithToken2" time="0.104" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho" time="0.308" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience" time="0.384" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="36" name="RsaKeySignatureTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.258" timestamp="17 Mar 2021 09:03:57 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" name="callEcho" time="0.258" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="31" name="PrimitiveInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="1.915" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedRawToken" time="0.155" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedJTI" time="0.164" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedUPN" time="0.139" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyIssuerClaim" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedExpiration" time="0.183" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomString" time="0.173" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomBoolean" time="0.214" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedSUB" time="0.141" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedAudience" time="0.339" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedGroups" time="0.138" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedIssuedAt" time="0.142" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="37" name="UnsecuredPingTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="4.653" timestamp="17 Mar 2021 09:04:54 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" name="callEchoNoAuth" time="4.653" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="32" name="PrincipalInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.401" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" name="verifyInjectedPrincipal" time="0.401" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="38" name="RolesAllowedSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe" tests="14" time="1.589" timestamp="17 Mar 2021 09:02:02 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignToken" time="0.065" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="33" name="ProviderInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.604" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.116" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoNeedsToken2Role" time="0.147" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim" time="0.152" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoWithoutCty" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt2" time="0.153" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho2" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI2" time="0.128" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRoleToken2" time="0.245" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken" time="0.121" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoWithToken2" time="0.155" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble2" time="0.154" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRole" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger2" time="0.179" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoBASIC" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience" time="0.454" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignEncryptToken" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt" time="0.145" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho" time="0.235" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble" time="0.154" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getPrincipalClass" time="0.197" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString" time="0.129" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoNoAuth" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject2" time="0.157" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject" time="0.136" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.205" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime2" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger" time="0.284" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken2" time="0.134" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString2" time="0.176" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim2" time="0.198" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience2" time="0.178" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="34" name="RequiredClaimsTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="2.192" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyUPN" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutExpiration" time="0.201" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyAudience" time="0.360" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifySubClaim" time="0.197" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutName" time="0.150" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyExpiration" time="0.160" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithIatOlderThanExp" time="0.396" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuedAt" time="0.165" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyJTI" time="0.171" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyOptionalAudience" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuerClaim" time="0.140" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="35" name="RolesAllowedTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="15" time="2.307" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callHeartbeat" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoAuth" time="0.115" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho" time="0.304" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignEncryptToken" time="0.090" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoNeedsToken2Role" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho2" time="0.112" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoBASIC" time="0.065" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRoleToken2" time="0.130" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRole" time="0.140" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getInjectedPrincipal" time="0.129" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="noTokenHeaderSetToCookie" time="0.606" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoGroups" time="0.104" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoWithToken2" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getPrincipalClass" time="0.113" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignToken" time="0.112" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="36" name="RsaKeySignatureTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.422" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" name="callEcho" time="0.422" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="37" name="UnsecuredPingTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="4.425" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" name="callEchoNoAuth" time="4.425" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="38" name="RolesAllowedSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe" tests="14" time="1.444" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho" time="0.270" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoWithoutCty" time="0.094" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoNeedsToken2Role" time="0.132" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRoleToken2" time="0.128" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getPrincipalClass" time="0.123" />
 
       <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getInjectedPrincipal" time="0.104" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callHeartbeat" time="0.027" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRole" time="0.143" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignEncryptToken" time="0.071" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callHeartbeat" time="0.033" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignToken" time="0.070" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoBASIC" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho2" time="0.096" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoNoAuth" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoWithToken2" time="0.106" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="39" name="TokenUtilsEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="8" time="1.797" timestamp="17 Mar 2021 09:05:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailIssuer" time="0.016" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="39" name="TokenUtilsEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="8" time="0.761" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailIssuer" time="0.007" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailExpired" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailAlgorithm" time="0.009" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidToken" time="0.015" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidToken" time="0.007" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailAlgorithm" time="0.025" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailEncryption" time="0.665" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidateSignedToken" time="0.013" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testExpGrace" time="0.017" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailJustExpired" time="0.016" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailJustExpired" time="0.008" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailEncryption" time="1.645" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailExpired" time="0.041" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testExpGrace" time="0.012" />
-
-  </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="40" name="TokenUtilsSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="7" time="0.235" timestamp="17 Mar 2021 09:05:55 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByECKeyVerifiedByRSKey" time="0.035" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptECSignedClaims" time="0.115" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaims" time="0.021" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaimsWithoutCty" time="0.019" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateSignedToken" time="0.006" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateEncryptedOnlyToken" time="0.007" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByRSKeyVerifiedByECKey" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidateSignedToken" time="0.007" />
 
   </testsuite>
-  <testsuite errors="0" failures="0" hostname="ebcprh2377mcdhdyk-n.fyre.ibm.com" id="41" name="TokenUtilsTest" package="org.eclipse.microprofile.jwt.tck.util" tests="18" time="1.545" timestamp="17 Mar 2021 09:04:54 GMT">
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken" time="0.010" />
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="40" name="TokenUtilsSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="7" time="0.167" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateEncryptedOnlyToken" time="0.006" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenEC256" time="0.023" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByRSKeyVerifiedByECKey" time="0.013" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpiredDeprecated" time="0.011" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaims" time="0.014" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignatureDeprecated" time="0.462" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateSignedToken" time="0.005" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByECKeyVerifiedByRSKey" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptECSignedClaims" time="0.082" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken1024BitKeyLength" time="0.116" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaimsWithoutCty" time="0.011" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuerDeprecated" time="0.010" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByECKeyVerifiedByRSKey" time="0.036" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGraceDeprecated" time="0.019" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="41" name="TokenUtilsTest" package="org.eclipse.microprofile.jwt.tck.util" tests="18" time="2.599" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken" time="0.007" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpired" time="0.009" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpiredDeprecated" time="0.014" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpiredDeprecated" time="0.011" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignature" time="0.428" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithmDeprecated" time="0.010" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenDeprecated" time="0.009" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuer" time="0.012" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByRSKeyVerifiedByECKey" time="0.012" />
-
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGrace" time="0.307" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGraceDeprecated" time="0.013" />
 
       <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithm" time="0.015" />
 
-      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpired" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignatureDeprecated" time="0.893" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByECKeyVerifiedByRSKey" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByRSKeyVerifiedByECKey" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithmDeprecated" time="0.006" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken1024BitKeyLength" time="0.248" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuer" time="0.009" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenDeprecated" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpiredDeprecated" time="0.010" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignature" time="1.034" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuerDeprecated" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGrace" time="0.237" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpired" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpired" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenEC256" time="0.018" />
 
   </testsuite>
 </testsuites>
-
 ----


### PR DESCRIPTION
Updates the MP JWT 1.2 TCK results from the 21.0.0.8-beta build.