### PR TITLE
Deliver MicroProfile 4.1 TCK results

### DIFF
--- a/microprofile/4.0/health/3.0/TCKResults.adoc
+++ b/microprofile/4.0/health/3.0/TCKResults.adoc
@@ -30,7 +30,6 @@ Java 8 Test results:
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8" ?>
-  </testsuite>
   <testsuite errors="0" failures="0" hostname="ebcprs2356mcdcuzh-n.fyre.ibm.com" id="1" name="CDIProducedProceduresTest" package="org.eclipse.microprofile.health.tck" tests="2" time="0.099" timestamp="17 Mar 2021 15:41:07 GMT">
       <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testFailureReadinessResponsePayload" time="0.052" />
       <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testSuccessfulLivenessResponsePayload" time="0.047" />

--- a/microprofile/4.1/TCKResults.adoc
+++ b/microprofile/4.1/TCKResults.adoc
@@ -1,0 +1,71 @@
+:page-layout: certification
+= MicroProfile 4.1 TCK Results Summary
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the MicroProfile TCK results for releases of MicroProfile 4.1.
+
+== Open Liberty 20.0.0.8-beta MicroProfile 4.1 Certification Summary
+
+MicroProfile 4.1 consists of 8 MicroProfile Specifications and 5 Jakarta EE 8 specfications.  
+
+* MicroProfile Config 2.0
+
+* MicroProfile Fault Tolerance 3.0
+
+* MicroProfile Health 3.1
+
+* MicroProfile JWT Authentication 1.2
+
+* MicroProfile Metrics 3.0
+
+* MicroProfile OpenAPI 2.0
+
+* MicroProfile OpenTracing 2.0
+
+* MicroProfile Rest Client 2.0
+
+* Jakarta Contexts and Dependency Injection 2.0
+
+* Jakarta RESTful Web Services 2.1
+
+* Jakarta JSON Binding 1.0
+
+* Jakarta JSON Processing 1.1
+
+* Jakarta Annotations 1.3
+
+=== Product Name, Version and download URL (if applicable):
+
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+
+In order to certify against MicroProfile 4.1, an implementation must pass the TCK tests for the eight included MicroProfile component specifications. Passing the TCKs for the five included Jakarta EE 8 specifications is optional.
+
+=== MicroProfile Component Sepecification Certification Summary
+* link:config/2.0/TCKResults.html[MicroProfile Config 2.0 TCK Result]
+
+* link:faulttolerance/3.0/TCKResults.html[MicroProfile Fault Tolerance 3.0 TCK Result]
+
+* link:health/3.1/TCKResults.html[MicroProfile Health 3.1 TCK Result]
+
+* link:mpjwt/1.2/TCKResults.html[MicroProfile JWT Authentication 1.2 TCK Result]
+
+* link:metrics/3.0/TCKResults.html[MicroProfile Metrics 3.0 TCK Result]
+
+* link:openapi/2.0/TCKResults.html[MicroProfile OpenAPI 2.0 TCK Result]
+
+* link:opentracing/2.0/TCKResults.html[MicroProfile OpenTracing 2.0 TCK Result]
+
+* link:restclient/2.0/TCKResults.html[MicroProfile Rest Client 2.0 TCK Result]
+
+=== Optional: Jakarta EE 8 Sepecification Certification Summary
+This link:../../jakartaee/webprofile/8/20.0.0.3-TCKResults.html[Jakarta EE 8 TCK Summary] lists the TCK Results for the following 5 Jakarta EE 8 specifications.
+
+* Jakarta Contexts and Dependency Injection 2.0
+
+* Jakarta RESTful Web Services 2.1
+
+* Jakarta JSON Binding 1.0
+
+* Jakarta JSON Processing 1.1
+
+* Jakarta Annotations 1.3

--- a/microprofile/4.1/config/2.0/TCKResults.adoc
+++ b/microprofile/4.1/config/2.0/TCKResults.adoc
@@ -1,0 +1,910 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Config 2.0.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile Config 2.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-config-2.0/microprofile-config-spec-2.0.html[MicroProfile Config 2.0]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+RHEL 8
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="1" name="ArrayConverterTest" package="org.eclipse.microprofile.config.tck" tests="138" time="13.885" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationArrayLookupProgrammatically_EE8_FEATURES" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalFloatListLookupProgrammatically_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateListLookupProgrammatically_EE8_FEATURES" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeSetInjection_EE8_FEATURES" time="0.145" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalCustomTypeListLookupProgrammatically_EE8_FEATURES" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetIntArrayConverter_EE8_FEATURES" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLocalTimeArrayConverter_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleArrayLookupProgrammatically_EE8_FEATURES" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeListLookupProgrammatically_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongSetInjection_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateArrayLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeSetInjection_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateListInjection_EE8_FEATURES" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalStringListLookupProgrammatically_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleSetInjection_EE8_FEATURES" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testbooleanListInjection_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetCustomTypeArrayConverter_EE8_FEATURES" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeArrayInjection_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetbooleanArrayConverter_EE8_FEATURES" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetdoubleArrayConverter_EE8_FEATURES" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongArrayLookupProgrammatically_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLongListLookupProgrammatically_EE8_FEATURES" time="0.100" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeListInjection_EE8_FEATURES" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLocalDateTimeArrayConverter_EE8_FEATURES" time="0.107" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testBooleanListLookupProgrammatically_EE8_FEATURES" time="0.198" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateListLookupProgrammatically_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testbooleanSetInjection_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriListLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetOffsetTimeArrayConverter_EE8_FEATURES" time="0.113" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatListInjection_EE8_FEATURES" time="0.139" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringArrayInjection_EE8_FEATURES" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalFloatArrayLookupProgrammatically_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalCustomTypeArrayLookupProgrammatically_EE8_FEATURES" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalInstantArrayLookupProgrammatically_EE8_FEATURES" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetStringArrayConverter_EE8_FEATURES" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongListLookupProgrammatically_EE8_FEATURES" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatListLookupProgrammatically_EE8_FEATURES" time="0.130" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriArrayLookupProgrammatically_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetUriArrayConverter_EE8_FEATURES" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateArrayInjection_EE8_FEATURES" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongListInjection_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLongArrayLookupProgrammatically_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntSetInjection_EE8_FEATURES" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeArrayLookupProgrammatically_EE8_FEATURES" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetIntegerArrayConverter_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntegerListLookupProgrammatically_EE8_FEATURES" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testBooleanArrayLookupProgrammatically_EE8_FEATURES" time="0.210" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetFloatArrayConverter_EE8_FEATURES" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleArrayInjection_EE8_FEATURES" time="0.193" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationListInjection_EE8_FEATURES" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDurationListLookupProgrammatically_EE8_FEATURES" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeListInjection_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUrlArrayLookupProgrammatically_EE8_FEATURES" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatArrayInjection_EE8_FEATURES" time="0.139" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetTimeListLookupProgrammatically_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatArrayLookupProgrammatically_EE8_FEATURES" time="0.157" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeListInjection_EE8_FEATURES" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantListInjection_EE8_FEATURES" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringSetInjection_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntListInjection_EE8_FEATURES" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeArrayInjection_EE8_FEATURES" time="0.151" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUriListLookupProgrammatically_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetInstantArrayConverter_EE8_FEATURES" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatSetInjection_EE8_FEATURES" time="0.110" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantArrayLookupProgrammatically_EE8_FEATURES" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleListLookupProgrammatically_EE8_FEATURES" time="0.168" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetDoubleArrayConverter_EE8_FEATURES" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeArrayInjection_EE8_FEATURES" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLocalDateArrayConverter_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeArrayInjection_EE8_FEATURES" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUrlArrayInjection_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationArrayInjection_EE8_FEATURES" time="0.173" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalTimeListLookupProgrammatically_EE8_FEATURES" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDoubleArrayLookupProgrammatically_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriSetInjection_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalIntegerArrayLookupProgrammatically_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantListLookupProgrammatically_EE8_FEATURES" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testBooleanArrayInjection_EE8_FEATURES" time="0.662" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntegerArrayLookupProgrammatically_EE8_FEATURES" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetUrlArrayConverter_EE8_FEATURES" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUriArrayLookupProgrammatically_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriArrayInjection_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalInstantListLookupProgrammatically_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetlongArrayCoverter_EE8_FEATURES" time="0.117" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testintArrayInjection_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testURLSetInjection_EE8_FEATURES" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetOffsetDateTimeArrayConverter_EE8_FEATURES" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringArrayLookupProgrammatically_EE8_FEATURES" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetfloatArrayConverter_EE8_FEATURES" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testbooleanArrayInjection_EE8_FEATURES" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateSetInjection_EE8_FEATURES" time="0.103" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeListLookupProgrammatically_EE8_FEATURES" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeSetInjection_EE8_FEATURES" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeListInjection_EE8_FEATURES" time="0.189" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeListLookupProgrammatically_EE8_FEATURES" time="0.171" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testfloatArrayInjection_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntArrayInjection_EE8_FEATURES" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testlongArrayInjection_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeArrayInjection_EE8_FEATURES" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUrlListLookupProgrammatically_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringListLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongArrayInjection_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantSetInjection_EE8_FEATURES" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalBooleanArrayLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeSetInjection_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalBooleanListLookupProgrammatically_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testURLListInjection_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantArrayInjection_EE8_FEATURES" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeListInjection_EE8_FEATURES" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalStringArrayLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriListInjection_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUrlArrayLookupProgrammatically_EE8_FEATURES" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationSetInjection_EE8_FEATURES" time="0.152" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDurationArrayLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUrlListLookupProgrammatically_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDoubleListLookupProgrammatically_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetDurationArrayConverter_EE8_FEATURES" time="0.117" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLongArrayCoverter_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeSetInjection_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleListInjection_EE8_FEATURES" time="0.172" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringListInjection_EE8_FEATURES" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetBooleanArrayConverter_EE8_FEATURES" time="0.127" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateArrayLookupProgrammatically_EE8_FEATURES" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationListLookupProgrammatically_EE8_FEATURES" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testdoubleArrayInjection_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalIntegerListLookupProgrammatically_EE8_FEATURES" time="0.084" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="2" name="AutoDiscoveredConfigSourceTest" package="org.eclipse.microprofile.config.tck" tests="3" time="0.406" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.AutoDiscoveredConfigSourceTest" name="testAutoDiscoveredConverterNotAddedAutomatically_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.AutoDiscoveredConfigSourceTest" name="testAutoDiscoveredConverterManuallyAdded_EE8_FEATURES" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.config.tck.AutoDiscoveredConfigSourceTest" name="testAutoDiscoveredConfigureSources_EE8_FEATURES" time="0.322" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="3" name="CDIPlainInjectionTest" package="org.eclipse.microprofile.config.tck" tests="4" time="0.509" timestamp="3 Jul 2021 07:26:32 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="canInjectSimpleValuesWhenDefined_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="injectedValuesAreEqualToProgrammaticValues_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="canInjectDefaultPropertyPath_EE8_FEATURES" time="0.366" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="canInjectDynamicValuesViaCdiProvider_EE8_FEATURES" time="0.034" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="4" name="CDIPropertyExpressionsTest" package="org.eclipse.microprofile.config.tck" tests="2" time="0.570" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPropertyExpressionsTest" name="expressionNoDefault_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPropertyExpressionsTest" name="expression_EE8_FEATURES" time="0.501" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="5" name="CDIPropertyNameMatchingTest" package="org.eclipse.microprofile.config.tck" tests="1" time="0.480" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPropertyNameMatchingTest" name="testPropertyFromEnvironmentVariables_EE8_FEATURES" time="0.480" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="6" name="CdiOptionalInjectionTest" package="org.eclipse.microprofile.config.tck" tests="2" time="0.367" timestamp="3 Jul 2021 07:26:32 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CdiOptionalInjectionTest" name="testOptionalInjectionWithNoDefaultValueOrElseIsReturned_EE8_FEATURES" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CdiOptionalInjectionTest" name="testOptionalInjection_EE8_FEATURES" time="0.331" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="7" name="ClassConverterTest" package="org.eclipse.microprofile.config.tck" tests="3" time="0.459" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ClassConverterTest" name="testGetClassConverter_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ClassConverterTest" name="testClassConverterWithLookup_EE8_FEATURES" time="0.375" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ClassConverterTest" name="testConverterForClassLoadedInBean_EE8_FEATURES" time="0.036" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="8" name="ConfigPropertiesTest" package="org.eclipse.microprofile.config.tck" tests="7" time="0.586" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesWithoutPrefix_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesPlainInjection_EE8_FEATURES" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesDefaultOnBean_EE8_FEATURES" time="0.350" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesNoPrefixOnBeanThenSupplyPrefix_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesNoPrefixOnBean_EE8_FEATURES" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testNoConfigPropertiesAnnotationInjection_EE8_FEATURES" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesWithPrefix_EE8_FEATURES" time="0.031" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="9" name="ConfigProviderTest" package="org.eclipse.microprofile.config.tck" tests="9" time="0.647" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testNonExistingConfigKey_EE8_FEATURES" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testDynamicValueInPropertyConfigSource_EE8_FEATURES" time="0.333" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testGetConfigSources_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testGetPropertyNames_EE8_FEATURES" time="0.035" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testInjectedConfigSerializable_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testJavaConfigPropertyFilesConfigSource_EE8_FEATURES" time="0.033" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testEnvironmentConfigSource_EE8_FEATURES" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testPropertyConfigSource_EE8_FEATURES" time="0.035" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testNonExistingConfigKeyGet_EE8_FEATURES" time="0.040" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="10" name="ConfigValueTest" package="org.eclipse.microprofile.config.tck" tests="3" time="0.451" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigValueTest" name="configValueEmpty_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigValueTest" name="configValue_EE8_FEATURES" time="0.365" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigValueTest" name="configValueInjection_EE8_FEATURES" time="0.036" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="11" name="ConverterTest" package="org.eclipse.microprofile.config.tck" tests="92" time="6.197" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDurationCoverter_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetCharConverter_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetcharConverter_EE8_FEATURES" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetShortConverter_Broken_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetBooleanConverter_EE8_FEATURES" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testURIConverterBroken_EE8_FEATURES" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetByteConverter_Broken_EE8_FEATURES" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetIntegerConverter_Broken_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testshort_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetTime_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetDateTimeConverter_Broken_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetZoneOffsetConverter_EE8_FEATURES" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetZoneOffsetConverter_Broken_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateConverter_Broken_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateTimeConverter_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDonaldConversionWithLambdaConverter_EE8_FEATURES" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetDateTime_Broken_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testfloat_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testZoneOffset_Broken_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testFloat_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testShort_Broken_EE8_FEATURES" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testNoDonaldConverterByDefault_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testByte_EE8_FEATURES" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetTimeConverter_Broken_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInteger_EE8_FEATURES" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testConverterSerialization_EE8_FEATURES" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetshortConverter_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInstant_Broken_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDouble_EE8_FEATURES" time="0.100" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDate_Broken_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLongConverter_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInt_EE8_FEATURES" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testbyte_EE8_FEATURES" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDateTime_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalTime_Broken_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetFloatConverter_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testChar_Broken_EE8_FEATURES" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInteger_Broken_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetfloatConverter_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testchar_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetDateTimeConverter_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetCustomConverter_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetInstantConverter_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetURIConverterBroken_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testBoolean_EE8_FEATURES" time="0.424" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testCustomConverter_EE8_FEATURES" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDonaldConversionWithMultipleLambdaConverters_EE8_FEATURES" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDuckConverterWithMultipleConverters_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetIntegerConverter_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalTimeConverter_Broken_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDuckConversionWithMultipleConverters_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDate_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetTimeConverter_EE8_FEATURES" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testdouble_EE8_FEATURES" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInstant_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testlong_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDateTime_Broken_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetCharConverter_Broken_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateTimeConverter_Broken_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetByteConverter_EE8_FEATURES" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetInstantConverter_Broken_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetlongConverter_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testZoneOffset_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDurationConverter_Broken_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testFloat_Broken_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLong_EE8_FEATURES" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetConverterSerialization_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDonaldConverterWithMultipleLambdaConverters_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDouble_Broken_EE8_FEATURES" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetURIConverter_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLongConverter_Broken_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testShort_EE8_FEATURES" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateConverter_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetDateTime_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetTime_Broken_EE8_FEATURES" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetdoubleConverter_EE8_FEATURES" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDoubleConverter_EE8_FEATURES" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetIntConverter_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDuration_Broken_EE8_FEATURES" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetbyteConverter_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetShortConverter_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDonaldConverterWithLambdaConverter_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testURIConverter_EE8_FEATURES" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testChar_EE8_FEATURES" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDoubleConverter_Broken_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testByte_Broken_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetFloatConverter_Broken_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDonaldNotConvertedByDefault_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalTime_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLong_Broken_EE8_FEATURES" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalTimeConverter_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDuration_EE8_FEATURES" time="0.055" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="12" name="CustomConfigSourceTest" package="org.eclipse.microprofile.config.tck" tests="1" time="0.331" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConfigSourceTest" name="testConfigSourceProvider_EE8_FEATURES" time="0.331" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="13" name="CustomConverterTest" package="org.eclipse.microprofile.config.tck" tests="20" time="1.339" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetIntPrimitiveConverter_EE8_FEATURES" time="0.027" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testInteger_EE8_FEATURES" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetBooleanPrimitiveConverter_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetDoublePrimitiveConverter_EE8_FEATURES" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testLongPrimitive_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testBoolean_EE8_FEATURES" time="0.340" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetLongConverter_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetDoubleConverter_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testDoublePrimitive_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testCharPrimitive_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetCharPrimitiveConverter_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetLongPrimitiveConverter_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testCharacter_EE8_FEATURES" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetBooleanConverter_EE8_FEATURES" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetCharacterConverter_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetIntegerConverter_EE8_FEATURES" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testBooleanPrimitive_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testDouble_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testLong_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testIntPrimitive_EE8_FEATURES" time="0.039" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="14" name="ImplicitConverterTest" package="org.eclipse.microprofile.config.tck" tests="19" time="1.427" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterStringCt_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterCharSequenceParseJavaTime_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterCharSequenceParseConverter_EE8_FEATURES" time="0.392" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterSquenceParseBeforeConstructorConverter_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterSquenceValueOfBeforeParse_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterSquenceParseBeforeConstructor_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterSquenceValueOfBeforeParseConverter_EE8_FEATURES" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterStringCtConverter_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterStringOfConverter_EE8_FEATURES" time="0.122" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterSquenceOfBeforeValueOfConverter_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterStringValueOf_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterEnumValueOf_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterCharSequenceParseJavaTimeInjection_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterEnumValueOfConverter_EE8_FEATURES" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterSquenceOfBeforeValueOf_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterCharSequenceParseJavaTimeConverter_EE8_FEATURES" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterStringOf_EE8_FEATURES" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterStringValueOfConverter_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterCharSequenceParse_EE8_FEATURES" time="0.058" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="15" name="PropertyExpressionsTest" package="org.eclipse.microprofile.config.tck" tests="16" time="1.385" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="simpleExpression_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="noExpression_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="composedExpressions_EE8_FEATURES" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpression_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpressionComposed_EE8_FEATURES" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="escape_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpressionEmpty_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="infiniteExpansion_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="withoutExpansion_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="arrayEscapes_EE8_FEATURES" time="0.493" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="multipleExpansions_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="noExpressionComposed_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="expressionMissing_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="escapeBraces_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpressionComposedEmpty_EE8_FEATURES" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="multipleExpressions_EE8_FEATURES" time="0.063" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="16" name="WarPropertiesLocationTest" package="org.eclipse.microprofile.config.tck" tests="1" time="0.337" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.WarPropertiesLocationTest" name="testReadPropertyInWar_EE8_FEATURES" time="0.337" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="17" name="ConfigPropertiesMissingPropertyInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.010" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.ConfigPropertiesMissingPropertyInjectionTest" name="test_EE8_FEATURES" time="0.010" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="18" name="MissingConverterOnInstanceInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.011" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.MissingConverterOnInstanceInjectionTest" name="test_EE8_FEATURES" time="0.011" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="19" name="MissingValueOnInstanceInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.010" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.MissingValueOnInstanceInjectionTest" name="test_EE8_FEATURES" time="0.010" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="20" name="MissingValueOnObserverMethodInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.004" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.MissingValueOnObserverMethodInjectionTest" name="test_EE8_FEATURES" time="0.004" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="21" name="WrongConverterOnInstanceInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.007" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.WrongConverterOnInstanceInjectionTest" name="test_EE8_FEATURES" time="0.007" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="22" name="DefaultConfigSourceOrdinalTest" package="org.eclipse.microprofile.config.tck.configsources" tests="2" time="0.450" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.configsources.DefaultConfigSourceOrdinalTest" name="testOrdinalForEnv_EE8_FEATURES" time="0.406" />
+      <testcase classname="org.eclipse.microprofile.config.tck.configsources.DefaultConfigSourceOrdinalTest" name="testOrdinalForSystemProps_EE8_FEATURES" time="0.044" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="23" name="NullConvertersTest" package="org.eclipse.microprofile.config.tck.converters" tests="1" time="0.592" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.NullConvertersTest" name="nulls_EE8_FEATURES" time="0.592" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="24" name="ConvertedNullValueBrokenInjectionTest" package="org.eclipse.microprofile.config.tck.converters.convertToNull" tests="1" time="0.019" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueBrokenInjectionTest" name="test_EE8_FEATURES" time="0.019" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="25" name="ConvertedNullValueTest" package="org.eclipse.microprofile.config.tck.converters.convertToNull" tests="3" time="0.644" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueTest" name="testGetOptionalValue_EE8_FEATURES" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueTest" name="testDefaultValueNotUsed_EE8_FEATURES" time="0.505" />
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueTest" name="testGetValue_EE8_FEATURES" time="0.071" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="26" name="EmptyValuesTestProgrammaticLookup" package="org.eclipse.microprofile.config.tck.emptyvalue" tests="28" time="2.205" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooCommaStringGetOptionalValues_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooCommaStringGetValue_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaBarStringGetValue_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testMissingStringGetValueArray_EE8_FEATURES" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testMissingStringGetOptionalValue_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetValue_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testDoubleCommaStringGetOptionalValues_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testSpaceStringGetOptionalValue_EE8_FEATURES" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetOptionalValueAsArrayOrList_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetOptionalValue_EE8_FEATURES" time="0.462" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooBarStringGetOptionalValues_EE8_FEATURES" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooCommaStringGetValueArray_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testEmptyStringGetValueArray_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaBarStringGetOptionalValues_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooBarStringGetValueArray_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testSpaceStringGetValueArray_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testSpaceStringGetValue_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testMissingStringGetValue_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaStringGetValueArray_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaBarStringGetValueArray_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testEmptyStringGetOptionalValue_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testDoubleCommaStringGetValueArray_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetValueArray_EE8_FEATURES" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaStringGetOptionalValue_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testEmptyStringGetValue_EE8_FEATURES" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaStringGetValue_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooBarStringGetValue_EE8_FEATURES" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testDoubleCommaStringGetValue_EE8_FEATURES" time="0.053" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="27" name="EmptyValuesTest" package="org.eclipse.microprofile.config.tck.emptyvalue" tests="1" time="0.006" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTest" name="test_EE8_FEATURES" time="0.006" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="28" name="ConfigPropertyFileProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.430" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.ConfigPropertyFileProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.430" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="29" name="DevConfigProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.370" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.DevConfigProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.370" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="30" name="InvalidConfigProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.394" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.InvalidConfigProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.394" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="31" name="ProdProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.338" timestamp="3 Jul 2021 07:26:32 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.ProdProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.338" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="32" name="TestConfigProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.415" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.TestConfigProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.415" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1605qmwhd35-n.fyre.ibm.com" id="33" name="TestCustomConfigProfile" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.305" timestamp="3 Jul 2021 07:26:33 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.TestCustomConfigProfile" name="testConfigProfileWithDev_EE8_FEATURES" time="0.305" />
+  </testsuite>
+</testsuites>
+----
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="1" name="ArrayConverterTest" package="org.eclipse.microprofile.config.tck" tests="138" time="14.836" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUriListLookupProgrammatically_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUrlArrayInjection_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetDurationArrayConverter_EE8_FEATURES" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.120" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongSetInjection_EE8_FEATURES" time="0.124" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriSetInjection_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testintArrayInjection_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeSetInjection_EE8_FEATURES" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetBooleanArrayConverter_EE8_FEATURES" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testbooleanListInjection_EE8_FEATURES" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeSetInjection_EE8_FEATURES" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalCustomTypeArrayLookupProgrammatically_EE8_FEATURES" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateArrayLookupProgrammatically_EE8_FEATURES" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetdoubleArrayConverter_EE8_FEATURES" time="0.135" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUrlArrayLookupProgrammatically_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetCustomTypeArrayConverter_EE8_FEATURES" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalIntegerArrayLookupProgrammatically_EE8_FEATURES" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLongArrayLookupProgrammatically_EE8_FEATURES" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUriArrayLookupProgrammatically_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationListInjection_EE8_FEATURES" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalFloatListLookupProgrammatically_EE8_FEATURES" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeSetInjection_EE8_FEATURES" time="0.179" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.103" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeArrayInjection_EE8_FEATURES" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeListInjection_EE8_FEATURES" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongArrayInjection_EE8_FEATURES" time="0.117" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetUriArrayConverter_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalBooleanArrayLookupProgrammatically_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetStringArrayConverter_EE8_FEATURES" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testfloatArrayInjection_EE8_FEATURES" time="0.100" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringArrayInjection_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongListInjection_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongListLookupProgrammatically_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringArrayLookupProgrammatically_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUrlListLookupProgrammatically_EE8_FEATURES" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantArrayLookupProgrammatically_EE8_FEATURES" time="0.100" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalCustomTypeListLookupProgrammatically_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testBooleanListLookupProgrammatically_EE8_FEATURES" time="0.154" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleSetInjection_EE8_FEATURES" time="0.172" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeArrayInjection_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationListLookupProgrammatically_EE8_FEATURES" time="0.147" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntSetInjection_EE8_FEATURES" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantListInjection_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDoubleListLookupProgrammatically_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLongListLookupProgrammatically_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringListInjection_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDurationArrayLookupProgrammatically_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testURLSetInjection_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetOffsetDateTimeArrayConverter_EE8_FEATURES" time="0.103" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalStringArrayLookupProgrammatically_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatListLookupProgrammatically_EE8_FEATURES" time="0.141" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntListInjection_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateSetInjection_EE8_FEATURES" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUrlListLookupProgrammatically_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.100" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testdoubleArrayInjection_EE8_FEATURES" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalUrlArrayLookupProgrammatically_EE8_FEATURES" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetIntegerArrayConverter_EE8_FEATURES" time="0.120" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntegerListLookupProgrammatically_EE8_FEATURES" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleArrayLookupProgrammatically_EE8_FEATURES" time="0.155" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeListLookupProgrammatically_EE8_FEATURES" time="0.113" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriArrayInjection_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalIntegerListLookupProgrammatically_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriArrayLookupProgrammatically_EE8_FEATURES" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleArrayInjection_EE8_FEATURES" time="0.140" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationArrayLookupProgrammatically_EE8_FEATURES" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalInstantListLookupProgrammatically_EE8_FEATURES" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDurationListLookupProgrammatically_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalInstantArrayLookupProgrammatically_EE8_FEATURES" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLocalDateArrayConverter_EE8_FEATURES" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringListLookupProgrammatically_EE8_FEATURES" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetlongArrayCoverter_EE8_FEATURES" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testlongArrayInjection_EE8_FEATURES" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateArrayLookupProgrammatically_EE8_FEATURES" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleListInjection_EE8_FEATURES" time="0.158" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeListInjection_EE8_FEATURES" time="0.142" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeArrayLookupProgrammatically_EE8_FEATURES" time="0.180" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLocalDateTimeArrayConverter_EE8_FEATURES" time="0.129" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetfloatArrayConverter_EE8_FEATURES" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalTimeListInjection_EE8_FEATURES" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeListLookupProgrammatically_EE8_FEATURES" time="0.147" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.119" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeListInjection_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLongArrayCoverter_EE8_FEATURES" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationArrayInjection_EE8_FEATURES" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testBooleanArrayLookupProgrammatically_EE8_FEATURES" time="0.169" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntArrayInjection_EE8_FEATURES" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatArrayInjection_EE8_FEATURES" time="0.167" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateListLookupProgrammatically_EE8_FEATURES" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalDateTimeListLookupProgrammatically_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantSetInjection_EE8_FEATURES" time="0.141" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalFloatArrayLookupProgrammatically_EE8_FEATURES" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriListInjection_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatArrayLookupProgrammatically_EE8_FEATURES" time="0.163" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeArrayInjection_EE8_FEATURES" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantListLookupProgrammatically_EE8_FEATURES" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testStringSetInjection_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateListInjection_EE8_FEATURES" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalBooleanListLookupProgrammatically_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeSetInjection_EE8_FEATURES" time="0.152" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testInstantArrayInjection_EE8_FEATURES" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDurationSetInjection_EE8_FEATURES" time="0.155" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateArrayInjection_EE8_FEATURES" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetIntArrayConverter_EE8_FEATURES" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testURLListInjection_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testbooleanSetInjection_EE8_FEATURES" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetbooleanArrayConverter_EE8_FEATURES" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testUriListLookupProgrammatically_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatSetInjection_EE8_FEATURES" time="0.144" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalDoubleArrayLookupProgrammatically_EE8_FEATURES" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testFloatListInjection_EE8_FEATURES" time="0.165" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetDoubleArrayConverter_EE8_FEATURES" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetFloatArrayConverter_EE8_FEATURES" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalStringListLookupProgrammatically_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalLocalTimeListLookupProgrammatically_EE8_FEATURES" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetDateTimeArrayLookupProgrammatically_EE8_FEATURES" time="0.119" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testbooleanArrayInjection_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetLocalTimeArrayConverter_EE8_FEATURES" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testBooleanArrayInjection_EE8_FEATURES" time="0.624" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetUrlArrayConverter_EE8_FEATURES" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testCustomTypeArrayInjection_EE8_FEATURES" time="0.165" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetInstantArrayConverter_EE8_FEATURES" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetDateTimeSetInjection_EE8_FEATURES" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeListInjection_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateTimeArrayInjection_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLongArrayLookupProgrammatically_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testIntegerArrayLookupProgrammatically_EE8_FEATURES" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOptionalOffsetTimeListLookupProgrammatically_EE8_FEATURES" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testGetOffsetTimeArrayConverter_EE8_FEATURES" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testLocalDateListLookupProgrammatically_EE8_FEATURES" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testDoubleListLookupProgrammatically_EE8_FEATURES" time="0.157" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ArrayConverterTest" name="testOffsetTimeListLookupProgrammatically_EE8_FEATURES" time="0.130" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="2" name="AutoDiscoveredConfigSourceTest" package="org.eclipse.microprofile.config.tck" tests="3" time="0.457" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.AutoDiscoveredConfigSourceTest" name="testAutoDiscoveredConverterManuallyAdded_EE8_FEATURES" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.config.tck.AutoDiscoveredConfigSourceTest" name="testAutoDiscoveredConverterNotAddedAutomatically_EE8_FEATURES" time="0.035" />
+      <testcase classname="org.eclipse.microprofile.config.tck.AutoDiscoveredConfigSourceTest" name="testAutoDiscoveredConfigureSources_EE8_FEATURES" time="0.384" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="3" name="CDIPlainInjectionTest" package="org.eclipse.microprofile.config.tck" tests="4" time="0.587" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="canInjectSimpleValuesWhenDefined_EE8_FEATURES" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="injectedValuesAreEqualToProgrammaticValues_EE8_FEATURES" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="canInjectDefaultPropertyPath_EE8_FEATURES" time="0.357" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPlainInjectionTest" name="canInjectDynamicValuesViaCdiProvider_EE8_FEATURES" time="0.056" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="4" name="CDIPropertyExpressionsTest" package="org.eclipse.microprofile.config.tck" tests="2" time="0.557" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPropertyExpressionsTest" name="expressionNoDefault_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPropertyExpressionsTest" name="expression_EE8_FEATURES" time="0.503" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="5" name="CDIPropertyNameMatchingTest" package="org.eclipse.microprofile.config.tck" tests="1" time="0.492" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CDIPropertyNameMatchingTest" name="testPropertyFromEnvironmentVariables_EE8_FEATURES" time="0.492" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="6" name="CdiOptionalInjectionTest" package="org.eclipse.microprofile.config.tck" tests="2" time="0.424" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CdiOptionalInjectionTest" name="testOptionalInjectionWithNoDefaultValueOrElseIsReturned_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CdiOptionalInjectionTest" name="testOptionalInjection_EE8_FEATURES" time="0.376" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="7" name="ClassConverterTest" package="org.eclipse.microprofile.config.tck" tests="3" time="0.481" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ClassConverterTest" name="testGetClassConverter_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ClassConverterTest" name="testClassConverterWithLookup_EE8_FEATURES" time="0.387" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ClassConverterTest" name="testConverterForClassLoadedInBean_EE8_FEATURES" time="0.045" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="8" name="ConfigPropertiesTest" package="org.eclipse.microprofile.config.tck" tests="7" time="0.782" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesNoPrefixOnBean_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesDefaultOnBean_EE8_FEATURES" time="0.425" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesWithoutPrefix_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesWithPrefix_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testNoConfigPropertiesAnnotationInjection_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesPlainInjection_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigPropertiesTest" name="testConfigPropertiesNoPrefixOnBeanThenSupplyPrefix_EE8_FEATURES" time="0.051" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="9" name="ConfigProviderTest" package="org.eclipse.microprofile.config.tck" tests="9" time="0.769" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testGetPropertyNames_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testNonExistingConfigKeyGet_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testDynamicValueInPropertyConfigSource_EE8_FEATURES" time="0.351" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testPropertyConfigSource_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testEnvironmentConfigSource_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testNonExistingConfigKey_EE8_FEATURES" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testGetConfigSources_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testJavaConfigPropertyFilesConfigSource_EE8_FEATURES" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigProviderTest" name="testInjectedConfigSerializable_EE8_FEATURES" time="0.057" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="10" name="ConfigValueTest" package="org.eclipse.microprofile.config.tck" tests="3" time="0.487" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigValueTest" name="configValueInjection_EE8_FEATURES" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigValueTest" name="configValueEmpty_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConfigValueTest" name="configValue_EE8_FEATURES" time="0.375" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="11" name="ConverterTest" package="org.eclipse.microprofile.config.tck" tests="92" time="6.082" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetCharConverter_Broken_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDate_EE8_FEATURES" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetIntegerConverter_Broken_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testZoneOffset_Broken_EE8_FEATURES" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testshort_EE8_FEATURES" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDonaldConversionWithLambdaConverter_EE8_FEATURES" time="0.120" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetURIConverter_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetDateTimeConverter_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testBoolean_EE8_FEATURES" time="0.551" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalTimeConverter_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLong_Broken_EE8_FEATURES" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalTime_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetInstantConverter_Broken_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testdouble_EE8_FEATURES" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testchar_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetIntegerConverter_EE8_FEATURES" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInstant_EE8_FEATURES" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetURIConverterBroken_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDuration_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetDateTime_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDate_Broken_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateConverter_Broken_EE8_FEATURES" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetInstantConverter_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetDateTimeConverter_Broken_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testFloat_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDonaldConversionWithMultipleLambdaConverters_EE8_FEATURES" time="0.116" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDuration_Broken_EE8_FEATURES" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetlongConverter_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testCustomConverter_EE8_FEATURES" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testURIConverter_EE8_FEATURES" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetIntConverter_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDonaldNotConvertedByDefault_EE8_FEATURES" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testURIConverterBroken_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalTime_Broken_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetZoneOffsetConverter_Broken_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetByteConverter_Broken_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetTime_Broken_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testbyte_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testShort_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testZoneOffset_EE8_FEATURES" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalTimeConverter_Broken_EE8_FEATURES" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLongConverter_Broken_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLong_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDouble_EE8_FEATURES" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInt_EE8_FEATURES" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetByteConverter_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLongConverter_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDateTime_Broken_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetCustomConverter_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testChar_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testConverterSerialization_EE8_FEATURES" time="0.149" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDonaldConverterWithMultipleLambdaConverters_EE8_FEATURES" time="0.123" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInteger_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInstant_Broken_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetBooleanConverter_EE8_FEATURES" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetFloatConverter_EE8_FEATURES" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetConverterSerialization_EE8_FEATURES" time="0.211" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateConverter_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDurationConverter_Broken_EE8_FEATURES" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testByte_EE8_FEATURES" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDoubleConverter_EE8_FEATURES" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testlong_EE8_FEATURES" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetshortConverter_EE8_FEATURES" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateTimeConverter_Broken_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDuckConversionWithMultipleConverters_EE8_FEATURES" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetfloatConverter_EE8_FEATURES" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testNoDonaldConverterByDefault_EE8_FEATURES" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testDouble_Broken_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testChar_Broken_EE8_FEATURES" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testByte_Broken_EE8_FEATURES" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testLocalDateTime_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetdoubleConverter_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetCharConverter_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDuckConverterWithMultipleConverters_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testInteger_Broken_EE8_FEATURES" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetcharConverter_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetLocalDateTimeConverter_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetShortConverter_Broken_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDoubleConverter_Broken_EE8_FEATURES" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetTimeConverter_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetTime_EE8_FEATURES" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testfloat_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testFloat_Broken_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDurationCoverter_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetShortConverter_EE8_FEATURES" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetFloatConverter_Broken_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetDonaldConverterWithLambdaConverter_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetbyteConverter_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testShort_Broken_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetOffsetTimeConverter_Broken_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testGetZoneOffsetConverter_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ConverterTest" name="testOffsetDateTime_Broken_EE8_FEATURES" time="0.052" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="12" name="CustomConfigSourceTest" package="org.eclipse.microprofile.config.tck" tests="1" time="0.368" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConfigSourceTest" name="testConfigSourceProvider_EE8_FEATURES" time="0.368" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="13" name="CustomConverterTest" package="org.eclipse.microprofile.config.tck" tests="20" time="1.527" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetIntegerConverter_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testDouble_EE8_FEATURES" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testCharacter_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testIntPrimitive_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetLongPrimitiveConverter_EE8_FEATURES" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetBooleanConverter_EE8_FEATURES" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetIntPrimitiveConverter_EE8_FEATURES" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testLongPrimitive_EE8_FEATURES" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetLongConverter_EE8_FEATURES" time="0.151" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetBooleanPrimitiveConverter_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testInteger_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testCharPrimitive_EE8_FEATURES" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetDoubleConverter_EE8_FEATURES" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testBooleanPrimitive_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetCharacterConverter_EE8_FEATURES" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testDoublePrimitive_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetDoublePrimitiveConverter_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testGetCharPrimitiveConverter_EE8_FEATURES" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testLong_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.CustomConverterTest" name="testBoolean_EE8_FEATURES" time="0.373" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="14" name="ImplicitConverterTest" package="org.eclipse.microprofile.config.tck" tests="19" time="1.261" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterSquenceValueOfBeforeParse_EE8_FEATURES" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterSquenceValueOfBeforeParseConverter_EE8_FEATURES" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterStringOf_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterCharSequenceParseJavaTime_EE8_FEATURES" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterStringCtConverter_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterSquenceParseBeforeConstructorConverter_EE8_FEATURES" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterEnumValueOf_EE8_FEATURES" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterSquenceOfBeforeValueOfConverter_EE8_FEATURES" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterCharSequenceParseJavaTimeConverter_EE8_FEATURES" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterEnumValueOfConverter_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterCharSequenceParseConverter_EE8_FEATURES" time="0.373" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterStringOfConverter_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterStringValueOf_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testGetImplicitConverterStringValueOfConverter_EE8_FEATURES" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterCharSequenceParse_EE8_FEATURES" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterSquenceOfBeforeValueOf_EE8_FEATURES" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterSquenceParseBeforeConstructor_EE8_FEATURES" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterCharSequenceParseJavaTimeInjection_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.ImplicitConverterTest" name="testImplicitConverterStringCt_EE8_FEATURES" time="0.060" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="15" name="PropertyExpressionsTest" package="org.eclipse.microprofile.config.tck" tests="16" time="1.376" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="withoutExpansion_EE8_FEATURES" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="multipleExpressions_EE8_FEATURES" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpression_EE8_FEATURES" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="escape_EE8_FEATURES" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpressionComposedEmpty_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="noExpression_EE8_FEATURES" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpressionComposed_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="expressionMissing_EE8_FEATURES" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="arrayEscapes_EE8_FEATURES" time="0.526" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="noExpressionComposed_EE8_FEATURES" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="infiniteExpansion_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="composedExpressions_EE8_FEATURES" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="multipleExpansions_EE8_FEATURES" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="defaultExpressionEmpty_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="escapeBraces_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.PropertyExpressionsTest" name="simpleExpression_EE8_FEATURES" time="0.048" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="16" name="WarPropertiesLocationTest" package="org.eclipse.microprofile.config.tck" tests="1" time="0.294" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.WarPropertiesLocationTest" name="testReadPropertyInWar_EE8_FEATURES" time="0.294" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="17" name="ConfigPropertiesMissingPropertyInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.013" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.ConfigPropertiesMissingPropertyInjectionTest" name="test_EE8_FEATURES" time="0.013" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="18" name="MissingConverterOnInstanceInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.007" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.MissingConverterOnInstanceInjectionTest" name="test_EE8_FEATURES" time="0.007" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="19" name="MissingValueOnInstanceInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.006" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.MissingValueOnInstanceInjectionTest" name="test_EE8_FEATURES" time="0.006" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="20" name="MissingValueOnObserverMethodInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.004" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.MissingValueOnObserverMethodInjectionTest" name="test_EE8_FEATURES" time="0.004" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="21" name="WrongConverterOnInstanceInjectionTest" package="org.eclipse.microprofile.config.tck.broken" tests="1" time="0.021" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.broken.WrongConverterOnInstanceInjectionTest" name="test_EE8_FEATURES" time="0.021" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="22" name="DefaultConfigSourceOrdinalTest" package="org.eclipse.microprofile.config.tck.configsources" tests="2" time="1.005" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.configsources.DefaultConfigSourceOrdinalTest" name="testOrdinalForSystemProps_EE8_FEATURES" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.config.tck.configsources.DefaultConfigSourceOrdinalTest" name="testOrdinalForEnv_EE8_FEATURES" time="0.926" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="23" name="NullConvertersTest" package="org.eclipse.microprofile.config.tck.converters" tests="1" time="0.574" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.NullConvertersTest" name="nulls_EE8_FEATURES" time="0.574" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="24" name="ConvertedNullValueBrokenInjectionTest" package="org.eclipse.microprofile.config.tck.converters.convertToNull" tests="1" time="0.008" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueBrokenInjectionTest" name="test_EE8_FEATURES" time="0.008" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="25" name="ConvertedNullValueTest" package="org.eclipse.microprofile.config.tck.converters.convertToNull" tests="3" time="0.764" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueTest" name="testGetValue_EE8_FEATURES" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueTest" name="testDefaultValueNotUsed_EE8_FEATURES" time="0.641" />
+      <testcase classname="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueTest" name="testGetOptionalValue_EE8_FEATURES" time="0.068" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="26" name="EmptyValuesTestProgrammaticLookup" package="org.eclipse.microprofile.config.tck.emptyvalue" tests="28" time="2.620" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaStringGetOptionalValue_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaStringGetValue_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testEmptyStringGetOptionalValue_EE8_FEATURES" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testMissingStringGetValueArray_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooCommaStringGetValue_EE8_FEATURES" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooCommaStringGetOptionalValues_EE8_FEATURES" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaBarStringGetValueArray_EE8_FEATURES" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooBarStringGetValueArray_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetOptionalValueAsArrayOrList_EE8_FEATURES" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testMissingStringGetOptionalValue_EE8_FEATURES" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testEmptyStringGetValue_EE8_FEATURES" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooCommaStringGetValueArray_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testSpaceStringGetValueArray_EE8_FEATURES" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testEmptyStringGetValueArray_EE8_FEATURES" time="0.144" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaBarStringGetOptionalValues_EE8_FEATURES" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testMissingStringGetValue_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testDoubleCommaStringGetOptionalValues_EE8_FEATURES" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooBarStringGetOptionalValues_EE8_FEATURES" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetValue_EE8_FEATURES" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetValueArray_EE8_FEATURES" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testSpaceStringGetOptionalValue_EE8_FEATURES" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaStringGetValueArray_EE8_FEATURES" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testDoubleCommaStringGetValueArray_EE8_FEATURES" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testDoubleCommaStringGetValue_EE8_FEATURES" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testSpaceStringGetValue_EE8_FEATURES" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testCommaBarStringGetValue_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testFooBarStringGetValue_EE8_FEATURES" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTestProgrammaticLookup" name="testBackslashCommaStringGetOptionalValue_EE8_FEATURES" time="0.616" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="27" name="EmptyValuesTest" package="org.eclipse.microprofile.config.tck.emptyvalue" tests="1" time="0.004" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.emptyvalue.EmptyValuesTest" name="test_EE8_FEATURES" time="0.004" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="28" name="ConfigPropertyFileProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.438" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.ConfigPropertyFileProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.438" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="29" name="DevConfigProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.413" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.DevConfigProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.413" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="30" name="InvalidConfigProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.385" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.InvalidConfigProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.385" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="31" name="ProdProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.344" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.ProdProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.344" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="32" name="TestConfigProfileTest" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.395" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.TestConfigProfileTest" name="testConfigProfileWithDev_EE8_FEATURES" time="0.395" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh2169qmyd0pw-n.fyre.ibm.com" id="33" name="TestCustomConfigProfile" package="org.eclipse.microprofile.config.tck.profile" tests="1" time="0.356" timestamp="3 Jul 2021 07:53:36 GMT">
+      <testcase classname="org.eclipse.microprofile.config.tck.profile.TestCustomConfigProfile" name="testConfigProfileWithDev_EE8_FEATURES" time="0.356" />
+  </testsuite>
+</testsuites>
+----

--- a/microprofile/4.1/faulttolerance/3.0/TCKResults.adoc
+++ b/microprofile/4.1/faulttolerance/3.0/TCKResults.adoc
@@ -1,0 +1,1370 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Fault Tolerance 3.0.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile Fault Tolerance 3.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-fault-tolerance-3.0/microprofile-fault-tolerance-spec-3.0.html[MicroProfile Fault Tolerance 3.0]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+RHEL 8
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="1" name="AsyncCancellationTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="5" time="22.004" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelledButRemainsInBulkhead" time="6.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelledDoesNotRetry" time="3.059" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelledWhileQueued" time="6.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelWithoutInterrupt" time="6.298" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancel" time="0.543" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="2" name="AsyncFallbackTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="6" time="0.738" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncFallbackFutureCompletesExceptionally" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncCSFallbackSuccess" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncFallbackSuccess" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncCSFallbackMethodThrows" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncFallbackMethodThrows" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncCSFallbackFutureCompletesExceptionally" time="0.440" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="3" name="AsyncTimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="3" time="27.564" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest" name="testAsyncNoTimeout" time="3.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest" name="testAsyncTimeout" time="12.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest" name="testAsyncClassLevelTimeout" time="12.468" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="4" name="AsynchronousCSTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="7" time="2.210" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testClassLevelAsyncIsNotFinished" time="0.542" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncIsFinished" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testClassLevelAsyncIsFinished" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncCompletesExceptionallyWhenCompletedExceptionally" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncIsNotFinished" time="0.558" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncCompletesExceptionallyWhenExceptionThrown" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncCallbacksChained" time="0.892" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="5" name="AsynchronousTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="6" time="1.263" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncIsFinished" time="0.861" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testClassLevelAsyncIsNotFinished" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncRequestContextWithFuture" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testClassLevelAsyncIsFinished" time="0.155" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncIsNotFinished" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncRequestContextWithCompletionStage" time="0.056" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="6" name="CircuitBreakerBulkheadTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="3" time="6.750" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest" name="testCircuitBreaker" time="3.567" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest" name="testCircuitBreakerAroundBulkheadSync" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest" name="testCircuitBreakerAroundBulkheadAsync" time="3.081" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="7" name="CircuitBreakerExceptionHierarchyTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="27" time="2.343" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE1S" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsException" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE0S" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE2" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsError" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE1S" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE1S" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE2S" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE0" time="0.559" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsError" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE2" time="0.128" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE1" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE2S" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsRuntimeException" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsRuntimeException" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE0" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsException" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE1" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsException" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE2S" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE2" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE0S" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE1" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE0S" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsError" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsRuntimeException" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE0" time="0.074" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="8" name="CircuitBreakerInitialSuccessTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="2.463" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerInitialSuccessTest" name="testCircuitInitialSuccessDefaultSuccessThreshold" time="2.463" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="9" name="CircuitBreakerLateSuccessTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="2.504" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerLateSuccessTest" name="testCircuitLateSuccessDefaultSuccessThreshold" time="2.504" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="10" name="CircuitBreakerRetryTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="12" time="23.653" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testClassLevelCircuitOpenWithMoreRetries" time="0.461" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testRetriesSucceedWhenCircuitClosesAsync" time="6.101" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testNoRetriesIfAbortOnAsync" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMoreRetriesAsync" time="0.168" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithFewRetriesAsync" time="0.268" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testClassLevelCircuitOpenWithFewRetries" time="0.250" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMultiTimeouts" time="4.930" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMultiTimeoutsAsync" time="4.023" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testNoRetriesIfNotRetryOnAsync" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testRetriesSucceedWhenCircuitCloses" time="6.105" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMoreRetries" time="0.605" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithFewRetries" time="0.582" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="11" name="CircuitBreakerTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="9" time="6.019" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testRollingWindowCircuitOpen" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitClosedThenOpen" time="0.446" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitReClose" time="0.576" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testClassLevelCircuitOverrideNoDelay" time="0.566" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitHighSuccessThreshold" time="2.070" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testClassLevelCircuitBase" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testClassLevelCircuitOverride" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitDefaultSuccessThreshold" time="2.081" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testRollingWindowCircuitOpen2" time="0.059" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="12" name="CircuitBreakerTimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="2" time="15.521" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTimeoutTest" name="testTimeout" time="6.471" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTimeoutTest" name="testTimeoutWithoutFailOn" time="9.050" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="13" name="ConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="5" time="4.828" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testClassLevelConfigMaxRetries" time="0.767" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testConfigMaxDuration" time="1.092" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testConfigMaxRetries" time="1.145" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testClassLevelConfigMethodOverrideMaxRetries" time="0.306" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testClassLevelConfigMaxDuration" time="1.518" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="14" name="FallbackExceptionHierarchyTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="27" time="1.900" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsRuntimeException" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE1" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE2" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsException" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE0S" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsException" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE2S" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE2S" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE1S" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE1" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE0S" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE0" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE0" time="0.385" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE1" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE0S" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE1S" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE2S" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE0" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsRuntimeException" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsRuntimeException" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE2" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsException" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsError" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsError" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE1S" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE2" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsError" time="0.056" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="15" name="FallbackTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="9" time="3.182" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testStandaloneHandlerFallback" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackSuccess" time="0.309" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackMethodWithArgsSuccess" time="0.116" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackTimeout" time="1.248" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackMethodSuccess" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testClassLevelFallbackSuccess" time="0.920" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testStandaloneMethodFallback" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackWithBeanSuccess" time="0.276" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbacktNoTimeout" time="0.156" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="16" name="RetryConditionTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="19" time="9.334" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetrySuccess" time="0.200" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryWithAbortOnFalse" time="0.216" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryParallelExceptionally" time="1.173" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryOnFalse" time="0.214" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryWithAbortOnTrue" time="0.195" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnFalse" time="0.154" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryParallelSuccess" time="0.982" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnFalseAndAbortOnTrueThrowingAChildCustomException" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnTrue" time="0.190" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testNoAsynRetryOnMethodException" time="0.250" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryWithAbortOnTrue" time="0.143" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryCompletionStageWithException" time="0.256" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testNoAsynWilNotRetryExceptionally" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryChainSuccess" time="1.863" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnTrueThrowingAChildCustomException" time="0.204" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testAsyncRetryExceptionally" time="0.636" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryChainExceptionally" time="2.073" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryWithAbortOnFalse" time="0.122" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryOnTrue" time="0.356" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="17" name="RetryExceptionHierarchyTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="27" time="2.207" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE1" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE2S" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE0" time="0.671" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE1" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE1S" time="0.030" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsError" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE1S" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE2" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE2S" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsException" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE0" time="0.035" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsRuntimeException" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE0S" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsException" time="0.193" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE2S" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsRuntimeException" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE2" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE0" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE1" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsError" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE1S" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsException" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE2" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE0S" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE0S" time="0.220" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsRuntimeException" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsError" time="0.030" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="18" name="RetryTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="8" time="27.969" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryMaxDuration" time="1.076" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryMaxDurationSeconds" time="1.164" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testClassLevelRetryMaxDuration" time="1.542" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testClassLevelRetryMaxRetries" time="0.215" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testClassLevelRetryMaxDurationSeconds" time="1.236" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryWithDelay" time="19.378" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryWithNoDelayAndJitter" time="3.259" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryMaxRetries" time="0.099" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="19" name="RetryTimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="4" time="12.681" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryWithoutRetryOn" time="3.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryTimeout" time="6.046" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryNoTimeout" time="0.531" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryWithAbortOn" time="3.054" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="20" name="TimeoutGlobalConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="0.552" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutGlobalConfigTest" name="testTimeout" time="0.552" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="21" name="TimeoutMethodConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="0.582" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutMethodConfigTest" name="testTimeout" time="0.582" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="22" name="TimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="16" time="18.225" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultNoTimeout" time="1.905" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultTimeoutClassLevel" time="0.549" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testTimeoutClassLevel" time="1.037" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testTimeout" time="1.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTShorterNoTimeoutOverride" time="1.585" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultTimeoutOverride" time="2.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultTimeout" time="2.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testNoTimeoutClassLevel" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultNoTimeoutOverride" time="1.551" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTShorterTimeoutOverride" time="2.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultTimeout" time="0.543" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testNoTimeout" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testSecondsTimeout" time="2.044" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testSecondsNoTimeout" time="1.547" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultNoTimeout" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultNoTimeoutClassLevel" time="0.059" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="23" name="TimeoutUninterruptableTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="7" time="39.361" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeout" time="6.542" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncFallback" time="3.072" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsync" time="3.056" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncCS" time="3.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncBulkheadQueueTimed" time="3.660" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncBulkhead" time="10.863" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncRetry" time="9.106" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="24" name="ZeroRetryJitterTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="0.498" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ZeroRetryJitterTest" name="test" time="0.498" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="25" name="BulkheadAsynchRetryTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="8" time="56.135" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionThrownClassAsync" time="6.317" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testRetriesReenterBulkhead" time="9.127" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testRetriesJoinBackOfQueue" time="15.134" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testNoRetriesWithAbortOn" time="3.115" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionRetriedMethodAsync" time="6.101" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testNoRetriesWithoutRetryOn" time="3.102" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionRetriedClassAsync" time="6.953" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionThrownMethodAsync" time="6.286" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="26" name="BulkheadAsynchTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="9" time="52.750" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronous10" time="6.693" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronousQueueing5" time="6.198" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronous3" time="6.188" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronousQueueing5" time="6.193" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronousDefault" time="6.250" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronous3" time="6.240" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronousDefault" time="6.280" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronous10" time="6.235" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadCompletionStage" time="2.473" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="27" name="BulkheadFutureTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="4" time="0.973" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadClassAsynchFutureDoneAfterGet" time="0.564" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadMethodAsynchFutureDoneAfterGet" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadMethodAsynchFutureDoneWithoutGet" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadClassAsynchFutureDoneWithoutGet" time="0.184" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="28" name="BulkheadPressureTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="2" time="31.548" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadPressureTest" name="testBulkheadPressureSync" time="15.539" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadPressureTest" name="testBulkheadPressureAsync" time="16.009" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="29" name="BulkheadSynchConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="1" time="0.619" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest" name="testBulkheadClassSemaphore3" time="0.619" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="30" name="BulkheadSynchRetryTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="5" time="12.598" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testRetryTestExceptionMethod" time="6.056" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testNoRetriesWithAbortOn" time="0.428" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testRetryTestExceptionClass" time="6.034" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testNoRetriesWithoutRetryOn" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testNoRetriesWithMaxRetriesZero" time="0.034" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="31" name="BulkheadSynchTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="6" time="0.974" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadClassSemaphore3" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadMethodSemaphoreDefault" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadMethodSemaphore3" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadMethodSemaphore10" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadClassSemaphoreDefault" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadClassSemaphore10" time="0.525" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="32" name="BulkheadLifecycleTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle" tests="3" time="3.091" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle.BulkheadLifecycleTest" name="noSharingBetweenClassesWithCommonSuperclass" time="0.357" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle.BulkheadLifecycleTest" name="noSharingBetweenMethodsOfOneClass" time="0.325" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle.BulkheadLifecycleTest" name="noSharingBetweenClasses" time="2.409" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="33" name="CircuitBreakerConfigGlobalTest" package="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker" tests="1" time="1.048" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigGlobalTest" name="testCircuitDefaultSuccessThreshold" time="1.048" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="34" name="CircuitBreakerConfigOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker" tests="1" time="0.935" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigOnMethodTest" name="testCircuitDefaultSuccessThreshold" time="0.935" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="35" name="CircuitBreakerLifecycleTest" package="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle" tests="20" time="3.187" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassNoRedefinition" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="noSharingBetweenClasses" time="0.142" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodOverrideOnClassWithOverriddenMethod" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodMissingOnOverriddenMethod" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethod" time="0.159" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassMissingOnOverriddenMethod" time="0.137" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClass" time="0.515" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodNoRedefinition" time="0.133" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodOverrideOnClassWithOverriddenMethod" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodOverrideOnMethod" time="0.505" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodOverrideOnClass" time="0.132" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodOverrideOnClass" time="0.151" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodNoRedefinition" time="0.125" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassOverrideOnClass" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassOverrideOnClassWithOverriddenMethod" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="noSharingBetweenMethodsOfOneClass" time="0.156" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethod" time="0.121" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodMissingOnOverriddenMethod" time="0.160" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodOverrideOnMethod" time="0.116" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassOverrideOnMethod" time="0.095" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="36" name="BulkheadConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="2" time="3.527" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.BulkheadConfigTest" name="testConfigValue" time="0.470" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.BulkheadConfigTest" name="testWaitingTaskQueue" time="3.057" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="37" name="CircuitBreakerConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="6" time="19.097" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureFailureRatio" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureSuccessThreshold" time="12.336" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureFailOn" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureDelay" time="6.484" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureRequestVolumeThreshold" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureSkipOn" time="0.081" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="38" name="CircuitBreakerSkipOnConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.694" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerSkipOnConfigTest" name="testConfigureSkipOn" time="0.694" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="39" name="ConfigPropertyGlobalVsClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.547" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassTest" name="propertyPriorityTest" time="0.547" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="40" name="ConfigPropertyGlobalVsClassVsMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.825" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassVsMethodTest" name="propertyPriorityTest" time="0.825" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="41" name="ConfigPropertyOnClassAndMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.841" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyOnClassAndMethodTest" name="propertyPriorityTest" time="0.841" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="42" name="FallbackApplyOnConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.325" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackApplyOnConfigTest" name="testApplyOn" time="0.325" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="43" name="FallbackConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="4" time="0.543" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testApplyOn" time="0.363" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testSkipOn" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testFallbackMethod" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testFallbackHandler" time="0.048" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="44" name="FallbackSkipOnConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.358" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackSkipOnConfigTest" name="testSkipOn" time="0.358" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="45" name="RetryConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="6" time="2.007" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigRetryOn" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigDelay" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigAbortOn" time="0.522" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigMaxDuration" time="1.073" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigMaxRetries" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigJitter" time="0.172" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="46" name="TimeoutConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="3" time="18.555" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.TimeoutConfigTest" name="testConfigUnit" time="6.071" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.TimeoutConfigTest" name="testConfigValue" time="6.071" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.TimeoutConfigTest" name="testConfigBoth" time="6.413" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="47" name="DisableAnnotationGloballyEnableOnClassDisableOnMethod" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.698" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testFallbackDisabled" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testTimeout" time="12.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testRetryDisabled" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testCircuitBreaker" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testAsync" time="2.434" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testBulkhead" time="0.055" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="48" name="DisableAnnotationGloballyEnableOnClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.198" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testCircuitBreaker" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testBulkhead" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testAsync" time="2.365" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testFallbackEnabled" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testTimeout" time="0.539" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testRetryEnabled" time="0.130" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="49" name="DisableAnnotationGloballyEnableOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.139" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testTimeout" time="0.532" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testRetryEnabled" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testFallbackDisabled" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testAsync" time="2.410" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testCircuitBreaker" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testBulkhead" time="0.038" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="50" name="DisableAnnotationGloballyTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.779" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testAsync" time="2.589" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testFallbackDisabled" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testTimeout" time="12.036" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testRetryDisabled" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testCircuitClosedThenOpen" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testBulkhead" time="0.040" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="51" name="DisableAnnotationOnClassEnableOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.198" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testRetryEnabled" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testTimeout" time="0.538" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testCircuitBreaker" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testBulkhead" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testFallbackDisabled" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testAsync" time="2.428" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="52" name="DisableAnnotationOnClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.538" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testAsync" time="2.362" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testCircuitClosedThenOpen" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testTimeout" time="12.031" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testFallbackDisabled" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testRetryDisabled" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testBulkhead" time="0.034" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="53" name="DisableAnnotationOnMethodsTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.767" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testAsync" time="2.475" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testRetryDisabled" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testCircuitClosedThenOpen" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testFallbackDisabled" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testBulkhead" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testTimeout" time="12.043" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="54" name="DisableFTEnableGloballyTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.302" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testRetryEnabled" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testCircuitBreaker" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testAsync" time="2.493" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testTimeout" time="0.544" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testFallbackEnabled" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testBulkhead" time="0.079" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="55" name="DisableFTEnableOnClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.200" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testAsync" time="2.415" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testBulkhead" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testTimeout" time="0.555" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testCircuitBreaker" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testFallbackEnabled" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testRetryEnabled" time="0.088" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="56" name="DisableFTEnableOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="5" time="3.077" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testTimeout" time="0.542" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testCircuitBreaker" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testAsync" time="2.359" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testRetryEnabled" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testBulkhead" time="0.053" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="57" name="DisableTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="4" time="3.590" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testRetryDisabled" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testFallbackSuccess" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testTimeout" time="3.024" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testCircuitClosedThenOpen" time="0.396" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="58" name="FallbackMethodAbstractTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.394" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodAbstractTest" name="fallbackMethodAbstract" time="0.394" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="59" name="FallbackMethodBasicTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.449" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodBasicTest" name="fallbackMethodBasic" time="0.449" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="60" name="FallbackMethodDefaultMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.451" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodDefaultMethodTest" name="fallbackMethodDefaultMethod" time="0.451" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="61" name="FallbackMethodGenericAbstractTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.523" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericAbstractTest" name="fallbackMethodGenericAbstract" time="0.523" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="62" name="FallbackMethodGenericArrayTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.401" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericArrayTest" name="fallbackMethodGenericArray" time="0.401" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="63" name="FallbackMethodGenericComplexTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.423" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericComplexTest" name="fallbackMethodGenericComplex" time="0.423" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="64" name="FallbackMethodGenericDeepTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.665" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericDeepTest" name="fallbackMethodGenericDeep" time="0.665" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="65" name="FallbackMethodGenericTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.401" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericTest" name="fallbackMethodGeneric" time="0.401" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="66" name="FallbackMethodGenericWildcardTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.417" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericWildcardTest" name="fallbackMethodGenericWildcard" time="0.417" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="67" name="FallbackMethodInPackageTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.395" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInPackageTest" name="fallbackMethodInPackage" time="0.395" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="68" name="FallbackMethodInterfaceTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.403" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInterfaceTest" name="fallbackMethodInterface" time="0.403" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="69" name="FallbackMethodOutOfPackageTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.004" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodOutOfPackageTest" name="fallbackMethodOutOfPackage" time="0.004" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="70" name="FallbackMethodPrivateTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.391" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodPrivateTest" name="fallbackMethodPrivate" time="0.391" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="71" name="FallbackMethodSubclassOverrideTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.499" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassOverrideTest" name="fallbackMethodSubclassOverride" time="0.499" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="72" name="FallbackMethodSubclassTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassTest" name="fallbackMethodSubclass" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="73" name="FallbackMethodSuperclassPrivateTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassPrivateTest" name="fallbackMethodSuperclassPrivate" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="74" name="FallbackMethodSuperclassTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.463" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassTest" name="fallbackMethodSuperclass" time="0.463" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="75" name="FallbackMethodVarargsTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.408" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodVarargsTest" name="fallbackMethodVarargs" time="0.408" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="76" name="FallbackMethodWildcardNegativeTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardNegativeTest" name="fallbackMethodWildcardNegative" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="77" name="FallbackMethodWildcardTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.412" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardTest" name="fallbackMethodWildcard" time="0.412" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="78" name="IncompatibleFallbackMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.004" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodTest" name="test" time="0.004" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="79" name="IncompatibleFallbackMethodWithArgsTest" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.004" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodWithArgsTest" name="test" time="0.004" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="80" name="IncompatibleFallbackPolicies" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackPolicies" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="81" name="IncompatibleFallbackTest" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.005" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackTest" name="test" time="0.005" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="82" name="FaultToleranceInterceptorTest" package="org.eclipse.microprofile.fault.tolerance.tck.interceptor" tests="2" time="0.601" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest" name="testAsync" time="0.529" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest" name="testRetryInterceptors" time="0.072" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="83" name="FaultToleranceInterceptorPriorityChangeAnnotationConfTest" package="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange" tests="2" time="0.460" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.FaultToleranceInterceptorPriorityChangeAnnotationConfTest" name="testRetryInterceptors" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.FaultToleranceInterceptorPriorityChangeAnnotationConfTest" name="testAsync" time="0.373" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="84" name="FaultToleranceInterceptorEnableByXmlTest" package="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling" tests="2" time="0.533" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest" name="testRetryInterceptors" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest" name="testAsync" time="0.475" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="85" name="InvalidAsynchronousClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousClassTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="86" name="InvalidAsynchronousMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousMethodTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="87" name="InvalidBulkheadAsynchQueueTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.014" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadAsynchQueueTest" name="test" time="0.014" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="88" name="InvalidBulkheadValueTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.006" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadValueTest" name="test" time="0.006" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="89" name="InvalidCircuitBreakerDelayTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerDelayTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="90" name="InvalidCircuitBreakerFailureRatioNegTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.022" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioNegTest" name="test" time="0.022" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="91" name="InvalidCircuitBreakerFailureRatioPosTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioPosTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="92" name="InvalidCircuitBreakerFailureReqVol0Test" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVol0Test" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="93" name="InvalidCircuitBreakerFailureReqVolNegTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVolNegTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="94" name="InvalidCircuitBreakerFailureSuccess0Test" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccess0Test" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="95" name="InvalidCircuitBreakerFailureSuccessNegTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.005" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccessNegTest" name="test" time="0.005" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="96" name="InvalidRetryDelayDurationTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.009" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayDurationTest" name="test" time="0.009" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="97" name="InvalidRetryDelayTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="98" name="InvalidRetryJitterTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryJitterTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="99" name="InvalidRetryMaxRetriesTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryMaxRetriesTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="100" name="InvalidTimeoutValueTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidTimeoutValueTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="101" name="AllMetricsTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="2" time="0.529" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest" name="testMetricUnits" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest" name="testAllMetrics" time="0.479" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="102" name="BulkheadMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="4" time="12.766" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricTest" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricRejectionTest" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricAsyncTest" time="6.538" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricHistogramTest" time="6.075" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="103" name="CircuitBreakerMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="1" time="9.440" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest" name="testCircuitBreakerMetric" time="9.440" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="104" name="ClashingNameTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="1" time="0.458" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClashingNameTest" name="testClashingName" time="0.458" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="105" name="ClassLevelMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="3" time="1.150" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest" name="testRetryMetricSuccessfulImmediately" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest" name="testRetryMetricUnsuccessful" time="0.607" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest" name="testRetryMetricSuccessfulAfterRetry" time="0.501" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="106" name="FallbackMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="2" time="0.604" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest" name="fallbackMetricMethodTest" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest" name="fallbackMetricHandlerTest" time="0.534" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="107" name="MetricsDisabledTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="1" time="0.407" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest" name="testMetricsDisabled" time="0.407" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="108" name="RetryMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="8" time="16.331" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricNonRetryableImmediately" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxDurationNoRetries" time="9.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricSuccessfulImmediately" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxDuration" time="6.454" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxRetries" time="0.234" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricNonRetryableAfterRetries" time="0.221" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxRetriesHitButNoRetry" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricSuccessfulAfterRetry" time="0.218" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="109" name="TimeoutMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="2" time="21.174" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest" name="testTimeoutMetric" time="6.692" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest" name="testTimeoutHistogram" time="14.482" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1604qmwhbfy-n.fyre.ibm.com" id="110" name="RetryVisibilityTest" package="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry" tests="17" time="4.635" timestamp="3 Jul 2021 08:23:21 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMOverridedClassLevelMethodOverride" time="0.178" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMNoRedefinition" time="0.238" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceOverrideClassLevelUsesClassLevelAnnotationWithMethodOverride" time="0.247" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROM" time="0.221" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMNoRedefinition" time="0.185" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCM" time="0.355" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="baseRetryServiceUsesDefaults" time="0.731" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceOverrideMethodLevelUsesMethodLevelAnnotation" time="0.231" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceRetryRemovedAtMethodLevel" time="0.208" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMOverridedClassLevelNoMethodOverride" time="0.300" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMRetryMissingOnMethod" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceDerivedClassNoRedefinition" time="0.268" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceOverrideClassLevelUsesClassLevelAnnotation" time="0.372" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMOverridedClassLevelMethodOverride" time="0.243" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMOverridedMethodLevel" time="0.202" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMOverridedClassLevelNoMethodOverride" time="0.390" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMRetryMissingOnMethod" time="0.212" />
+  </testsuite>
+</testsuites>
+----
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="1" name="AsyncCancellationTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="5" time="21.967" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelWithoutInterrupt" time="6.285" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelledDoesNotRetry" time="3.078" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancel" time="0.501" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelledWhileQueued" time="6.042" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest" name="testCancelledButRemainsInBulkhead" time="6.061" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="2" name="AsyncFallbackTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="6" time="0.658" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncFallbackSuccess" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncFallbackMethodThrows" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncCSFallbackSuccess" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncCSFallbackFutureCompletesExceptionally" time="0.408" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncCSFallbackMethodThrows" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest" name="testAsyncFallbackFutureCompletesExceptionally" time="0.050" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="3" name="AsyncTimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="3" time="27.504" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest" name="testAsyncNoTimeout" time="3.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest" name="testAsyncTimeout" time="12.044" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest" name="testAsyncClassLevelTimeout" time="12.411" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="4" name="AsynchronousCSTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="7" time="2.193" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncIsNotFinished" time="0.541" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testClassLevelAsyncIsNotFinished" time="0.578" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncIsFinished" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncCompletesExceptionallyWhenExceptionThrown" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncCallbacksChained" time="0.884" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testClassLevelAsyncIsFinished" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest" name="testAsyncCompletesExceptionallyWhenCompletedExceptionally" time="0.059" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="5" name="AsynchronousTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="6" time="1.338" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncIsNotFinished" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testClassLevelAsyncIsNotFinished" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncRequestContextWithCompletionStage" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testClassLevelAsyncIsFinished" time="0.167" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncRequestContextWithFuture" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" name="testAsyncIsFinished" time="0.941" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="6" name="CircuitBreakerBulkheadTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="3" time="6.575" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest" name="testCircuitBreaker" time="3.415" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest" name="testCircuitBreakerAroundBulkheadSync" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest" name="testCircuitBreakerAroundBulkheadAsync" time="3.076" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="7" name="CircuitBreakerExceptionHierarchyTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="27" time="2.102" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE2S" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE1" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsException" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE0" time="0.427" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsRuntimeException" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsRuntimeException" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE1S" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE2" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsError" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsException" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE1" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE0" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE0S" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE0S" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE2" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE1S" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE1" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE0" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsError" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE1S" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsE2S" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE2" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsRuntimeException" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsError" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceAthrowsE2S" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceBthrowsException" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest" name="serviceCthrowsE0S" time="0.050" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="8" name="CircuitBreakerInitialSuccessTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="2.467" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerInitialSuccessTest" name="testCircuitInitialSuccessDefaultSuccessThreshold" time="2.467" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="9" name="CircuitBreakerLateSuccessTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="2.372" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerLateSuccessTest" name="testCircuitLateSuccessDefaultSuccessThreshold" time="2.372" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="10" name="CircuitBreakerRetryTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="12" time="23.340" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testNoRetriesIfNotRetryOnAsync" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testClassLevelCircuitOpenWithMoreRetries" time="0.575" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testRetriesSucceedWhenCircuitCloses" time="6.121" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMultiTimeoutsAsync" time="3.773" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testRetriesSucceedWhenCircuitClosesAsync" time="6.099" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMoreRetriesAsync" time="0.556" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMoreRetries" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithFewRetries" time="0.510" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithMultiTimeouts" time="5.240" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testClassLevelCircuitOpenWithFewRetries" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testCircuitOpenWithFewRetriesAsync" time="0.110" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" name="testNoRetriesIfAbortOnAsync" time="0.079" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="11" name="CircuitBreakerTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="9" time="5.939" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitClosedThenOpen" time="0.368" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testRollingWindowCircuitOpen2" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testRollingWindowCircuitOpen" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testClassLevelCircuitBase" time="0.121" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitHighSuccessThreshold" time="2.076" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testClassLevelCircuitOverride" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitDefaultSuccessThreshold" time="2.077" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testCircuitReClose" time="0.556" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest" name="testClassLevelCircuitOverrideNoDelay" time="0.569" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="12" name="CircuitBreakerTimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="2" time="15.407" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTimeoutTest" name="testTimeoutWithoutFailOn" time="9.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTimeoutTest" name="testTimeout" time="6.353" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="13" name="ConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="5" time="3.697" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testClassLevelConfigMaxDuration" time="1.470" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testClassLevelConfigMethodOverrideMaxRetries" time="0.326" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testConfigMaxRetries" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testClassLevelConfigMaxRetries" time="0.731" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest" name="testConfigMaxDuration" time="1.104" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="14" name="FallbackExceptionHierarchyTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="27" time="1.668" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsException" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsRuntimeException" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE2" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE0S" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsError" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE0S" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE1S" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE1" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE2S" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE1" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE0" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE0" time="0.354" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE1" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE1S" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE2" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE1S" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsError" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE0" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsError" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE2" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsRuntimeException" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsE0S" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsException" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsRuntimeException" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceBthrowsE2S" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceAthrowsE2S" time="0.033" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest" name="serviceCthrowsException" time="0.038" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="15" name="FallbackTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="9" time="2.797" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbacktNoTimeout" time="0.173" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testStandaloneHandlerFallback" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testStandaloneMethodFallback" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackWithBeanSuccess" time="0.424" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackSuccess" time="0.235" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testClassLevelFallbackSuccess" time="0.637" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackMethodSuccess" time="0.113" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackTimeout" time="1.069" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest" name="testFallbackMethodWithArgsSuccess" time="0.059" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="16" name="RetryConditionTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="19" time="8.801" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnTrueThrowingAChildCustomException" time="0.357" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testNoAsynRetryOnMethodException" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryChainSuccess" time="1.938" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryWithAbortOnTrue" time="0.177" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnFalseAndAbortOnTrueThrowingAChildCustomException" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnFalse" time="0.150" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryCompletionStageWithException" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryWithAbortOnFalse" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryChainExceptionally" time="2.219" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testAsyncRetryExceptionally" time="0.455" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryWithAbortOnTrue" time="0.164" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryParallelExceptionally" time="0.992" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetrySuccess" time="0.210" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testNoAsynWilNotRetryExceptionally" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryOnFalse" time="0.188" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryWithAbortOnFalse" time="0.338" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryOnTrue" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testRetryParallelSuccess" time="1.012" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" name="testClassLevelRetryOnTrue" time="0.179" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="17" name="RetryExceptionHierarchyTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="27" time="1.941" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE1" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE2S" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE0S" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE1" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE0" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsRuntimeException" time="0.035" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE2" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsException" time="0.177" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsRuntimeException" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsException" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsError" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE2S" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE2S" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE0S" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE0S" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE2" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsException" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE0" time="0.617" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsError" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsError" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE0" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE1S" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE1" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsRuntimeException" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceBthrowsE1S" time="0.026" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceAthrowsE1S" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest" name="serviceCthrowsE2" time="0.047" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="18" name="RetryTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="8" time="29.409" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testClassLevelRetryMaxRetries" time="0.424" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testClassLevelRetryMaxDuration" time="1.390" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryWithNoDelayAndJitter" time="3.336" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryMaxDuration" time="1.102" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryWithDelay" time="20.748" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryMaxRetries" time="0.179" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testClassLevelRetryMaxDurationSeconds" time="1.179" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTest" name="testRetryMaxDurationSeconds" time="1.051" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="19" name="RetryTimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="4" time="12.747" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryTimeout" time="6.048" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryWithAbortOn" time="3.113" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryWithoutRetryOn" time="3.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" name="testRetryNoTimeout" time="0.529" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="20" name="TimeoutGlobalConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="0.551" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutGlobalConfigTest" name="testTimeout" time="0.551" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="21" name="TimeoutMethodConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="0.554" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutMethodConfigTest" name="testTimeout" time="0.554" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="22" name="TimeoutTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="16" time="18.274" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultTimeoutClassLevel" time="0.542" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testTimeoutClassLevel" time="1.076" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultNoTimeoutClassLevel" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultNoTimeoutOverride" time="1.547" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultTimeout" time="2.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultNoTimeout" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTShorterNoTimeoutOverride" time="1.553" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTShorterTimeoutOverride" time="2.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultTimeoutOverride" time="2.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testNoTimeout" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testLTDefaultTimeout" time="0.555" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testNoTimeoutClassLevel" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testTimeout" time="1.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testSecondsNoTimeout" time="1.550" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testSecondsTimeout" time="2.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest" name="testGTDefaultNoTimeout" time="1.942" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="23" name="TimeoutUninterruptableTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="7" time="39.227" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncRetry" time="9.110" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncBulkheadQueueTimed" time="3.660" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncCS" time="3.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncFallback" time="3.101" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeout" time="6.374" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsync" time="3.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest" name="testTimeoutAsyncBulkhead" time="10.869" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="24" name="ZeroRetryJitterTest" package="org.eclipse.microprofile.fault.tolerance.tck" tests="1" time="0.518" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.ZeroRetryJitterTest" name="test" time="0.518" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="25" name="BulkheadAsynchRetryTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="8" time="56.489" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testNoRetriesWithoutRetryOn" time="3.148" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionRetriedClassAsync" time="6.992" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionThrownMethodAsync" time="6.294" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testNoRetriesWithAbortOn" time="3.114" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testRetriesReenterBulkhead" time="9.151" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionRetriedMethodAsync" time="6.161" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testRetriesJoinBackOfQueue" time="15.191" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest" name="testBulkheadExceptionThrownClassAsync" time="6.438" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="26" name="BulkheadAsynchTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="9" time="52.709" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronousDefault" time="6.249" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronous10" time="6.598" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronousQueueing5" time="6.191" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronous10" time="6.253" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronous3" time="6.231" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadClassAsynchronousDefault" time="6.221" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronousQueueing5" time="6.298" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadCompletionStage" time="2.458" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest" name="testBulkheadMethodAsynchronous3" time="6.210" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="27" name="BulkheadFutureTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="4" time="0.942" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadClassAsynchFutureDoneAfterGet" time="0.466" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadMethodAsynchFutureDoneWithoutGet" time="0.159" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadClassAsynchFutureDoneWithoutGet" time="0.245" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest" name="testBulkheadMethodAsynchFutureDoneAfterGet" time="0.072" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="28" name="BulkheadPressureTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="2" time="31.722" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadPressureTest" name="testBulkheadPressureAsync" time="16.111" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadPressureTest" name="testBulkheadPressureSync" time="15.611" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="29" name="BulkheadSynchConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="1" time="0.949" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest" name="testBulkheadClassSemaphore3" time="0.949" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="30" name="BulkheadSynchRetryTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="5" time="12.654" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testNoRetriesWithMaxRetriesZero" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testRetryTestExceptionMethod" time="6.059" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testNoRetriesWithAbortOn" time="0.466" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testNoRetriesWithoutRetryOn" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest" name="testRetryTestExceptionClass" time="6.041" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="31" name="BulkheadSynchTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead" tests="6" time="0.963" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadMethodSemaphore10" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadClassSemaphoreDefault" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadMethodSemaphoreDefault" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadMethodSemaphore3" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadClassSemaphore3" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest" name="testBulkheadClassSemaphore10" time="0.479" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="32" name="BulkheadLifecycleTest" package="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle" tests="3" time="3.413" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle.BulkheadLifecycleTest" name="noSharingBetweenClasses" time="2.546" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle.BulkheadLifecycleTest" name="noSharingBetweenClassesWithCommonSuperclass" time="0.457" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle.BulkheadLifecycleTest" name="noSharingBetweenMethodsOfOneClass" time="0.410" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="33" name="CircuitBreakerConfigGlobalTest" package="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker" tests="1" time="0.917" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigGlobalTest" name="testCircuitDefaultSuccessThreshold" time="0.917" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="34" name="CircuitBreakerConfigOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker" tests="1" time="0.889" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigOnMethodTest" name="testCircuitDefaultSuccessThreshold" time="0.889" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="35" name="CircuitBreakerLifecycleTest" package="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle" tests="20" time="2.525" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassOverrideOnMethod" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodNoRedefinition" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodOverrideOnMethod" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="noSharingBetweenMethodsOfOneClass" time="0.129" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodNoRedefinition" time="0.129" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodMissingOnOverriddenMethod" time="0.187" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodOverrideOnClassWithOverriddenMethod" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodOverrideOnMethod" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethod" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethod" time="0.125" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassOverrideOnClassWithOverriddenMethod" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClass" time="0.396" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassOverrideOnClass" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassMissingOnOverriddenMethod" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassNoRedefinition" time="0.167" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodOverrideOnClass" time="0.156" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodOverrideOnClassWithOverriddenMethod" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="noSharingBetweenClasses" time="0.123" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnMethodMissingOnOverriddenMethod" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest" name="circuitBreakerOnClassAndMethodOverrideOnClass" time="0.120" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="36" name="BulkheadConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="2" time="3.475" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.BulkheadConfigTest" name="testWaitingTaskQueue" time="3.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.BulkheadConfigTest" name="testConfigValue" time="0.417" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="37" name="CircuitBreakerConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="6" time="19.439" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureSuccessThreshold" time="12.355" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureFailOn" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureFailureRatio" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureDelay" time="6.719" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureRequestVolumeThreshold" time="0.158" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest" name="testConfigureSkipOn" time="0.063" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="38" name="CircuitBreakerSkipOnConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.517" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerSkipOnConfigTest" name="testConfigureSkipOn" time="0.517" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="39" name="ConfigPropertyGlobalVsClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.978" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassTest" name="propertyPriorityTest" time="0.978" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="40" name="ConfigPropertyGlobalVsClassVsMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.749" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassVsMethodTest" name="propertyPriorityTest" time="0.749" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="41" name="ConfigPropertyOnClassAndMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.828" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyOnClassAndMethodTest" name="propertyPriorityTest" time="0.828" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="42" name="FallbackApplyOnConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.324" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackApplyOnConfigTest" name="testApplyOn" time="0.324" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="43" name="FallbackConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="4" time="0.592" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testFallbackMethod" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testSkipOn" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testFallbackHandler" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest" name="testApplyOn" time="0.450" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="44" name="FallbackSkipOnConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="1" time="0.352" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackSkipOnConfigTest" name="testSkipOn" time="0.352" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="45" name="RetryConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="6" time="2.248" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigAbortOn" time="0.434" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigMaxRetries" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigRetryOn" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigDelay" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigMaxDuration" time="1.075" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.RetryConfigTest" name="testConfigJitter" time="0.481" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="46" name="TimeoutConfigTest" package="org.eclipse.microprofile.fault.tolerance.tck.config" tests="3" time="18.488" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.TimeoutConfigTest" name="testConfigUnit" time="6.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.TimeoutConfigTest" name="testConfigValue" time="6.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.config.TimeoutConfigTest" name="testConfigBoth" time="6.383" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="47" name="DisableAnnotationGloballyEnableOnClassDisableOnMethod" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.569" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testFallbackDisabled" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testTimeout" time="12.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testBulkhead" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testCircuitBreaker" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testAsync" time="2.353" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod" name="testRetryDisabled" time="0.040" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="48" name="DisableAnnotationGloballyEnableOnClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.474" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testCircuitBreaker" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testBulkhead" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testFallbackEnabled" time="0.225" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testTimeout" time="0.534" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testRetryEnabled" time="0.202" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest" name="testAsync" time="2.370" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="49" name="DisableAnnotationGloballyEnableOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.147" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testRetryEnabled" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testTimeout" time="0.545" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testAsync" time="2.430" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testCircuitBreaker" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testFallbackDisabled" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest" name="testBulkhead" time="0.038" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="50" name="DisableAnnotationGloballyTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.535" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testCircuitClosedThenOpen" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testFallbackDisabled" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testAsync" time="2.368" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testRetryDisabled" time="0.030" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testTimeout" time="12.029" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest" name="testBulkhead" time="0.034" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="51" name="DisableAnnotationOnClassEnableOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.205" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testRetryEnabled" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testTimeout" time="0.549" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testAsync" time="2.413" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testCircuitBreaker" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testBulkhead" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest" name="testFallbackDisabled" time="0.062" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="52" name="DisableAnnotationOnClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.551" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testBulkhead" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testAsync" time="2.366" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testCircuitClosedThenOpen" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testTimeout" time="12.046" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testFallbackDisabled" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest" name="testRetryDisabled" time="0.026" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="53" name="DisableAnnotationOnMethodsTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="14.710" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testTimeout" time="12.031" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testBulkhead" time="0.033" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testAsync" time="2.440" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testRetryDisabled" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testFallbackDisabled" time="0.153" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest" name="testCircuitClosedThenOpen" time="0.025" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="54" name="DisableFTEnableGloballyTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.276" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testTimeout" time="0.548" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testAsync" time="2.479" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testBulkhead" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testFallbackEnabled" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testCircuitBreaker" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest" name="testRetryEnabled" time="0.064" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="55" name="DisableFTEnableOnClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="6" time="3.139" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testCircuitBreaker" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testBulkhead" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testFallbackEnabled" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testAsync" time="2.337" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testTimeout" time="0.559" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest" name="testRetryEnabled" time="0.066" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="56" name="DisableFTEnableOnMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="5" time="3.101" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testBulkhead" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testCircuitBreaker" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testRetryEnabled" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testAsync" time="2.332" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest" name="testTimeout" time="0.544" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="57" name="DisableTest" package="org.eclipse.microprofile.fault.tolerance.tck.disableEnv" tests="4" time="3.547" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testFallbackSuccess" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testRetryDisabled" time="0.129" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testCircuitClosedThenOpen" time="0.345" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest" name="testTimeout" time="3.031" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="58" name="FallbackMethodAbstractTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.352" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodAbstractTest" name="fallbackMethodAbstract" time="0.352" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="59" name="FallbackMethodBasicTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.363" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodBasicTest" name="fallbackMethodBasic" time="0.363" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="60" name="FallbackMethodDefaultMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.399" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodDefaultMethodTest" name="fallbackMethodDefaultMethod" time="0.399" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="61" name="FallbackMethodGenericAbstractTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.445" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericAbstractTest" name="fallbackMethodGenericAbstract" time="0.445" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="62" name="FallbackMethodGenericArrayTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.418" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericArrayTest" name="fallbackMethodGenericArray" time="0.418" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="63" name="FallbackMethodGenericComplexTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.440" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericComplexTest" name="fallbackMethodGenericComplex" time="0.440" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="64" name="FallbackMethodGenericDeepTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.665" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericDeepTest" name="fallbackMethodGenericDeep" time="0.665" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="65" name="FallbackMethodGenericTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.395" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericTest" name="fallbackMethodGeneric" time="0.395" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="66" name="FallbackMethodGenericWildcardTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.373" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericWildcardTest" name="fallbackMethodGenericWildcard" time="0.373" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="67" name="FallbackMethodInPackageTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.387" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInPackageTest" name="fallbackMethodInPackage" time="0.387" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="68" name="FallbackMethodInterfaceTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.349" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInterfaceTest" name="fallbackMethodInterface" time="0.349" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="69" name="FallbackMethodOutOfPackageTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.001" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodOutOfPackageTest" name="fallbackMethodOutOfPackage" time="0.001" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="70" name="FallbackMethodPrivateTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.378" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodPrivateTest" name="fallbackMethodPrivate" time="0.378" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="71" name="FallbackMethodSubclassOverrideTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.549" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassOverrideTest" name="fallbackMethodSubclassOverride" time="0.549" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="72" name="FallbackMethodSubclassTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.003" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassTest" name="fallbackMethodSubclass" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="73" name="FallbackMethodSuperclassPrivateTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassPrivateTest" name="fallbackMethodSuperclassPrivate" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="74" name="FallbackMethodSuperclassTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.378" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassTest" name="fallbackMethodSuperclass" time="0.378" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="75" name="FallbackMethodVarargsTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.347" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodVarargsTest" name="fallbackMethodVarargs" time="0.347" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="76" name="FallbackMethodWildcardNegativeTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.003" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardNegativeTest" name="fallbackMethodWildcardNegative" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="77" name="FallbackMethodWildcardTest" package="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod" tests="1" time="0.370" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardTest" name="fallbackMethodWildcard" time="0.370" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="78" name="IncompatibleFallbackMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="79" name="IncompatibleFallbackMethodWithArgsTest" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.003" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodWithArgsTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="80" name="IncompatibleFallbackPolicies" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackPolicies" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="81" name="IncompatibleFallbackTest" package="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig" tests="1" time="0.005" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackTest" name="test" time="0.005" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="82" name="FaultToleranceInterceptorTest" package="org.eclipse.microprofile.fault.tolerance.tck.interceptor" tests="2" time="0.370" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest" name="testAsync" time="0.305" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest" name="testRetryInterceptors" time="0.065" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="83" name="FaultToleranceInterceptorPriorityChangeAnnotationConfTest" package="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange" tests="2" time="0.617" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.FaultToleranceInterceptorPriorityChangeAnnotationConfTest" name="testAsync" time="0.395" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.FaultToleranceInterceptorPriorityChangeAnnotationConfTest" name="testRetryInterceptors" time="0.222" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="84" name="FaultToleranceInterceptorEnableByXmlTest" package="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling" tests="2" time="0.515" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest" name="testAsync" time="0.459" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest" name="testRetryInterceptors" time="0.056" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="85" name="InvalidAsynchronousClassTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousClassTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="86" name="InvalidAsynchronousMethodTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousMethodTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="87" name="InvalidBulkheadAsynchQueueTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadAsynchQueueTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="88" name="InvalidBulkheadValueTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadValueTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="89" name="InvalidCircuitBreakerDelayTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerDelayTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="90" name="InvalidCircuitBreakerFailureRatioNegTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.009" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioNegTest" name="test" time="0.009" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="91" name="InvalidCircuitBreakerFailureRatioPosTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioPosTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="92" name="InvalidCircuitBreakerFailureReqVol0Test" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVol0Test" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="93" name="InvalidCircuitBreakerFailureReqVolNegTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVolNegTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="94" name="InvalidCircuitBreakerFailureSuccess0Test" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccess0Test" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="95" name="InvalidCircuitBreakerFailureSuccessNegTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.001" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccessNegTest" name="test" time="0.001" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="96" name="InvalidRetryDelayDurationTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.004" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayDurationTest" name="test" time="0.004" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="97" name="InvalidRetryDelayTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.013" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayTest" name="test" time="0.013" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="98" name="InvalidRetryJitterTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.003" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryJitterTest" name="test" time="0.003" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="99" name="InvalidRetryMaxRetriesTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryMaxRetriesTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="100" name="InvalidTimeoutValueTest" package="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters" tests="1" time="0.002" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidTimeoutValueTest" name="test" time="0.002" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="101" name="AllMetricsTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="2" time="0.468" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest" name="testMetricUnits" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest" name="testAllMetrics" time="0.423" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="102" name="BulkheadMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="4" time="12.607" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricTest" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricRejectionTest" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricAsyncTest" time="6.392" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest" name="bulkheadMetricHistogramTest" time="6.067" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="103" name="CircuitBreakerMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="1" time="9.449" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest" name="testCircuitBreakerMetric" time="9.449" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="104" name="ClashingNameTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="1" time="0.452" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClashingNameTest" name="testClashingName" time="0.452" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="105" name="ClassLevelMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="3" time="1.334" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest" name="testRetryMetricSuccessfulAfterRetry" time="0.819" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest" name="testRetryMetricUnsuccessful" time="0.468" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest" name="testRetryMetricSuccessfulImmediately" time="0.047" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="106" name="FallbackMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="2" time="0.512" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest" name="fallbackMetricHandlerTest" time="0.434" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest" name="fallbackMetricMethodTest" time="0.078" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="107" name="MetricsDisabledTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="1" time="0.383" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest" name="testMetricsDisabled" time="0.383" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="108" name="RetryMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="8" time="16.800" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricSuccessfulAfterRetry" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricNonRetryableImmediately" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxDurationNoRetries" time="9.050" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricNonRetryableAfterRetries" time="0.201" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxRetries" time="0.897" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricSuccessfulImmediately" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxRetriesHitButNoRetry" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest" name="testRetryMetricMaxDuration" time="6.422" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="109" name="TimeoutMetricTest" package="org.eclipse.microprofile.fault.tolerance.tck.metrics" tests="2" time="21.018" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest" name="testTimeoutMetric" time="6.683" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest" name="testTimeoutHistogram" time="14.335" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0971qmyctyk-n.fyre.ibm.com" id="110" name="RetryVisibilityTest" package="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry" tests="17" time="5.067" timestamp="3 Jul 2021 08:58:57 GMT">
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMOverridedMethodLevel" time="0.280" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceOverrideClassLevelUsesClassLevelAnnotationWithMethodOverride" time="0.404" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="baseRetryServiceUsesDefaults" time="0.817" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceDerivedClassNoRedefinition" time="0.460" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMOverridedClassLevelNoMethodOverride" time="0.191" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMOverridedClassLevelNoMethodOverride" time="0.364" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMNoRedefinition" time="0.251" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMOverridedClassLevelMethodOverride" time="0.262" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceOverrideClassLevelUsesClassLevelAnnotation" time="0.162" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROM" time="0.499" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMNoRedefinition" time="0.286" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCMRetryMissingOnMethod" time="0.139" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceOverrideMethodLevelUsesMethodLevelAnnotation" time="0.300" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMRetryMissingOnMethod" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROMOverridedClassLevelMethodOverride" time="0.174" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceBaseROCM" time="0.153" />
+      <testcase classname="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest" name="serviceRetryRemovedAtMethodLevel" time="0.236" />
+  </testsuite>
+</testsuites>
+----

--- a/microprofile/4.1/health/3.1/TCKResults.adoc
+++ b/microprofile/4.1/health/3.1/TCKResults.adoc
@@ -1,0 +1,182 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Health 3.1.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile Health 3.1 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-health-3.1/microprofile-health-spec-3.1.html[MicroProfile Health 3.1]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+RHEL 8
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="1" name="CDIProducedProceduresTest" package="org.eclipse.microprofile.health.tck" tests="3" time="0.140" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testSuccessStartupResponsePayload" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testFailureReadinessResponsePayload" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testSuccessfulLivenessResponsePayload" time="0.051" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="2" name="ConfigTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.039" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.ConfigTest" name="testEmptyReadinessWithConfig" time="0.039" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="3" name="DelayedCheckTest" package="org.eclipse.microprofile.health.tck" tests="1" time="6.044" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.DelayedCheckTest" name="testSuccessResponsePayload" time="6.044" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="4" name="DelegateHealthSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.083" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.DelegateHealthSuccessfulTest" name="testSuccessfulDelegateInvocation" time="0.083" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="5" name="EnforceQualifierTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.027" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.EnforceQualifierTest" name="testFailureResponsePayload" time="0.027" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="6" name="HealthCheckResponseAttributesTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.058" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.HealthCheckResponseAttributesTest" name="testSuccessResponsePayload" time="0.058" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="7" name="HealthCheckResponseValidationTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.158" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.HealthCheckResponseValidationTest" name="testValidateConcreteHealthCheckResponse" time="0.158" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="8" name="JsonSchemaValidationTest" package="org.eclipse.microprofile.health.tck" tests="1" time="2.474" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.JsonSchemaValidationTest" name="testPayloadJsonVerifiesWithTheSpecificationSchema" time="2.474" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="9" name="MultipleLivenessFailedTest" package="org.eclipse.microprofile.health.tck" tests="2" time="0.123" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleLivenessFailedTest" name="testFailureLivenessResponsePayload" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleLivenessFailedTest" name="testSuccessfulReadinessResponsePayload" time="0.045" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="10" name="MultipleProceduresFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.083" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleProceduresFailedTest" name="testFailureResponsePayload" time="0.083" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="11" name="MultipleReadinessFailedTest" package="org.eclipse.microprofile.health.tck" tests="2" time="0.231" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleReadinessFailedTest" name="testFailureResponsePayload" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleReadinessFailedTest" name="testSuccessfulLivenessResponsePayload" time="0.070" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="12" name="MultipleStartupFailedTest" package="org.eclipse.microprofile.health.tck" tests="4" time="0.304" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testSuccessfulReadinessResponsePayload" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testFailingHealthResponsePayload" time="0.100" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testFailingStartupResponsePayload" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testSuccessfulLivenessResponsePayload" time="0.074" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="13" name="NoProcedureSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.036" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.NoProcedureSuccessfulTest" name="testSuccessResponsePayload" time="0.036" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="14" name="OnlySuccessfulProcedureTest" package="org.eclipse.microprofile.health.tck" tests="2" time="0.101" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.OnlySuccessfulProcedureTest" name="testSuccessfulLivenessResponsePayload" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.health.tck.OnlySuccessfulProcedureTest" name="testSuccessfulReadinessResponsePayload" time="0.034" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="15" name="SingleLivenessFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.073" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleLivenessFailedTest" name="testFailureResponsePayload" time="0.073" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="16" name="SingleLivenessSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.119" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleLivenessSuccessfulTest" name="testSuccessResponsePayload" time="0.119" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="17" name="SingleReadinessFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.071" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleReadinessFailedTest" name="testFailureResponsePayload" time="0.071" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="18" name="SingleReadinessSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.086" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleReadinessSuccessfulTest" name="testSuccessResponsePayload" time="0.086" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="19" name="SingleStartupFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.059" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleStartupFailedTest" name="testFailedResponsePayload" time="0.059" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2071qmwhqyx-n.fyre.ibm.com" id="20" name="SingleStartupSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.075" timestamp="3 Jul 2021 06:35:06 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleStartupSuccessfulTest" name="testSuccessResponsePayload" time="0.075" />
+  </testsuite>
+</testsuites>
+----
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="1" name="CDIProducedProceduresTest" package="org.eclipse.microprofile.health.tck" tests="3" time="0.125" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testSuccessStartupResponsePayload" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testSuccessfulLivenessResponsePayload" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest" name="testFailureReadinessResponsePayload" time="0.036" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="2" name="ConfigTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.037" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.ConfigTest" name="testEmptyReadinessWithConfig" time="0.037" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="3" name="DelayedCheckTest" package="org.eclipse.microprofile.health.tck" tests="1" time="6.057" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.DelayedCheckTest" name="testSuccessResponsePayload" time="6.057" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="4" name="DelegateHealthSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.118" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.DelegateHealthSuccessfulTest" name="testSuccessfulDelegateInvocation" time="0.118" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="5" name="EnforceQualifierTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.040" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.EnforceQualifierTest" name="testFailureResponsePayload" time="0.040" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="6" name="HealthCheckResponseAttributesTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.047" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.HealthCheckResponseAttributesTest" name="testSuccessResponsePayload" time="0.047" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="7" name="HealthCheckResponseValidationTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.156" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.HealthCheckResponseValidationTest" name="testValidateConcreteHealthCheckResponse" time="0.156" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="8" name="JsonSchemaValidationTest" package="org.eclipse.microprofile.health.tck" tests="1" time="1.988" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.JsonSchemaValidationTest" name="testPayloadJsonVerifiesWithTheSpecificationSchema" time="1.988" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="9" name="MultipleLivenessFailedTest" package="org.eclipse.microprofile.health.tck" tests="2" time="0.103" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleLivenessFailedTest" name="testFailureLivenessResponsePayload" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleLivenessFailedTest" name="testSuccessfulReadinessResponsePayload" time="0.043" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="10" name="MultipleProceduresFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.086" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleProceduresFailedTest" name="testFailureResponsePayload" time="0.086" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="11" name="MultipleReadinessFailedTest" package="org.eclipse.microprofile.health.tck" tests="2" time="0.222" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleReadinessFailedTest" name="testFailureResponsePayload" time="0.162" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleReadinessFailedTest" name="testSuccessfulLivenessResponsePayload" time="0.060" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="12" name="MultipleStartupFailedTest" package="org.eclipse.microprofile.health.tck" tests="4" time="0.243" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testFailingStartupResponsePayload" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testSuccessfulReadinessResponsePayload" time="0.024" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testSuccessfulLivenessResponsePayload" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.health.tck.MultipleStartupFailedTest" name="testFailingHealthResponsePayload" time="0.117" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="13" name="NoProcedureSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.034" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.NoProcedureSuccessfulTest" name="testSuccessResponsePayload" time="0.034" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="14" name="OnlySuccessfulProcedureTest" package="org.eclipse.microprofile.health.tck" tests="2" time="0.067" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.OnlySuccessfulProcedureTest" name="testSuccessfulLivenessResponsePayload" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.health.tck.OnlySuccessfulProcedureTest" name="testSuccessfulReadinessResponsePayload" time="0.027" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="15" name="SingleLivenessFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.076" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleLivenessFailedTest" name="testFailureResponsePayload" time="0.076" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="16" name="SingleLivenessSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.098" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleLivenessSuccessfulTest" name="testSuccessResponsePayload" time="0.098" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="17" name="SingleReadinessFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.083" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleReadinessFailedTest" name="testFailureResponsePayload" time="0.083" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="18" name="SingleReadinessSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.091" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleReadinessSuccessfulTest" name="testSuccessResponsePayload" time="0.091" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="19" name="SingleStartupFailedTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.107" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleStartupFailedTest" name="testFailedResponsePayload" time="0.107" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0980qmypso8-n.fyre.ibm.com" id="20" name="SingleStartupSuccessfulTest" package="org.eclipse.microprofile.health.tck" tests="1" time="0.072" timestamp="3 Jul 2021 06:37:05 GMT">
+      <testcase classname="org.eclipse.microprofile.health.tck.SingleStartupSuccessfulTest" name="testSuccessResponsePayload" time="0.072" />
+  </testsuite>
+</testsuites>
+
+
+----

--- a/microprofile/4.1/metrics/3.0/TCKResults.adoc
+++ b/microprofile/4.1/metrics/3.0/TCKResults.adoc
@@ -1,0 +1,766 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Metrics 3.0.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile Metrics 3.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-metrics-3.0/microprofile-metrics-spec-3.0.html[MicroProfile Metrics 3.0]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+RHEL 8
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" id="1" name="MetricFilterTest" package="org.eclipse.microprofile.metrics.tck" skipped="0" tests="1" time="0.361">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricFilterTest" name="theAllFilterMatchesAllMetrics" time="0.361" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="2" name="MetricIDTest" package="org.eclipse.microprofile.metrics.tck" skipped="0" tests="1" time="0.345">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricIDTest" name="removalTest" time="0.345" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="3" name="MetricRegistryTest" package="org.eclipse.microprofile.metrics.tck" skipped="0" tests="7" time="0.561">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="nameTest" time="0.343" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="registerTest" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="removeTest" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="useExistingMetaDataTest" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="testMetricRegistryType" time="0.03" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="sanitizeMetadataTest" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="conflictingMetadataTest" time="0.041" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="4" name="ApplicationScopedTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="0.459">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.ApplicationScopedTimedMethodBeanTest" name="timedMethodNotCalledYet" time="0.413" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.ApplicationScopedTimedMethodBeanTest" name="callTimedMethodOnce" time="0.046" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="5" name="GaugeInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="0.402">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.GaugeInjectionBeanTest" name="gaugeCalledWithDefaultValue" time="0.362" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.GaugeInjectionBeanTest" name="callGaugeAfterSetterCall" time="0.04" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="6" name="MeterInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="0.404">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.MeterInjectionBeanTest" name="meteredMethodNotCalledYet" time="0.366" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.MeterInjectionBeanTest" name="callMeteredMethodOnce" time="0.038" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="7" name="SimpleTimerInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="2.403">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.SimpleTimerInjectionBeanTest" name="simplyTimedMethodNotCalledYet" time="0.36" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.SimpleTimerInjectionBeanTest" name="callSimplyTimedMethodOnce" time="2.043" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="8" name="TimerInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="2.452">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.TimerInjectionBeanTest" name="timedMethodNotCalledYet" time="0.415" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.TimerInjectionBeanTest" name="callTimedMethodOnce" time="2.037" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="9" name="StereotypeCountedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi.stereotype" skipped="0" tests="2" time="0.39">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.stereotype.StereotypeCountedClassBeanTest" name="testWithMetadata" time="0.35" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.stereotype.StereotypeCountedClassBeanTest" name="testPlainAnnotation" time="0.04" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="10" name="InheritedGaugeMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.389">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedGaugeMethodBeanTest" name="gaugesCalledWithDefaultValues" time="0.364" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedGaugeMethodBeanTest" name="callGaugesAfterSetterCalls" time="0.025" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="11" name="InheritedSimplyTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.445">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedSimplyTimedMethodBeanTest" name="simplyTimedMethodsNotCalledYet" time="0.398" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedSimplyTimedMethodBeanTest" name="callSimplyTimedMethodsOnce" time="0.047" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="12" name="InheritedTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.417">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedTimedMethodBeanTest" name="timedMethodsNotCalledYet" time="0.374" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedTimedMethodBeanTest" name="callTimedMethodsOnce" time="0.043" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="13" name="VisibilitySimplyTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.359">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilitySimplyTimedMethodBeanTest" name="simplyTimedMethodsNotCalledYet" time="0.332" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilitySimplyTimedMethodBeanTest" name="callSimplyTimedMethodsOnce" time="0.027" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="14" name="VisibilityTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.409">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilityTimedMethodBeanTest" name="timedMethodsNotCalledYet" time="0.364" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilityTimedMethodBeanTest" name="callTimedMethodsOnce" time="0.045" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="15" name="ConcreteExtendedTimedBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.478">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="timedMethodNotCalledYet" time="0.343" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="extendedTimedMethodNotCalledYet" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="callTimedMethodOnce" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="callExtendedTimedMethodOnce" time="0.033" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="16" name="ConcreteTimedBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.457">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="timedMethodNotCalledYet" time="0.376" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="extendedTimedMethodNotCalledYet" time="0.022" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="callTimedMethodOnce" time="0.029" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="callExtendedTimedMethodOnce" time="0.03" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="17" name="ConcurrentGaugeFunctionalTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="84.563">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeFunctionalTest" name="testMinMax" time="84.505" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeFunctionalTest" name="testConcurrentInvocations" time="0.058" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="18" name="ConcurrentGaugeTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="0.414">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeTest" name="getCountTest" time="0.293" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeTest" name="incrementTest" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeTest" name="decrementTest" time="0.049" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="19" name="ConcurrentGaugedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.547">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedClassBeanTest" name="countedMethodsNotCalledYet" time="0.509" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedClassBeanTest" name="callCountedMethodsOnce" time="0.038" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="20" name="ConcurrentGaugedConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.292">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedConstructorBeanTest" name="countedConstructorCalled" time="0.292" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="21" name="ConcurrentGaugedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.67">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="countedMethodNotCalledYet" time="0.331" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="metricInjectionIntoTest" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="callCountedMethodOnce" time="0.05" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="removeCounterFromRegistry" time="0.247" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="22" name="CountedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.401">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedClassBeanTest" name="countedMethodsNotCalledYet" time="0.363" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedClassBeanTest" name="callCountedMethodsOnce" time="0.038" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="23" name="CountedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.469">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="countedMethodNotCalledYet" time="0.259" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="metricInjectionIntoTest" time="0.025" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="callCountedMethodOnce" time="0.035" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="removeCounterFromRegistry" time="0.15" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="24" name="CountedMethodTagBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.274">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodTagBeanTest" name="counterTagMethodsRegistered" time="0.245" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodTagBeanTest" name="countedTagMethodNotCalledYet" time="0.029" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="25" name="CounterFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.354">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterFieldBeanTest" name="counterFieldRegistered" time="0.315" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterFieldBeanTest" name="incrementCounterField" time="0.039" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="26" name="CounterTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="0.398">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterTest" name="getCountTest" time="0.323" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterTest" name="incrementTest" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterTest" name="incrementLongTest" time="0.041" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="27" name="DefaultNameMetricMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.337">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.DefaultNameMetricMethodBeanTest" name="metricMethodsWithDefaultNamingConvention" time="0.337" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="28" name="GaugeMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.347">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.GaugeMethodBeanTest" name="gaugeCalledWithDefaultValue" time="0.317" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.GaugeMethodBeanTest" name="callGaugeAfterSetterCall" time="0.03" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="29" name="GaugeTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.31">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.GaugeTest" name="testManualGauge" time="0.31" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="30" name="HistogramFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.369">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramFieldBeanTest" name="histogramFieldRegistered" time="0.336" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramFieldBeanTest" name="updateHistogramField" time="0.033" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="31" name="HistogramTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="15" time="0.815">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSum" time="0.287" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testCount" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot99thPercentile" time="0.024" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMax" time="0.03" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMin" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot98thPercentile" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMean" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotSize" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot95thPercentile" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testMetricRegistry" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMedian" time="0.029" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotStdDev" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotValues" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot999thPercentile" time="0.029" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot75thPercentile" time="0.041" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="32" name="MeterTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="75.368">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeterTest" name="testCount" time="0.305" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeterTest" name="testRates" time="75.063" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="33" name="MeteredClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.373">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredClassBeanTest" name="meteredMethodsNotCalledYet" time="0.311" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredClassBeanTest" name="callMeteredMethodsOnce" time="0.062" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="34" name="MeteredConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.322">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredConstructorBeanTest" name="meteredConstructorCalled" time="0.322" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="35" name="MeteredMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="0.529">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredMethodBeanTest" name="meteredMethodNotCalledYet" time="0.333" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredMethodBeanTest" name="callMeteredMethodOnce" time="0.027" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredMethodBeanTest" name="removeMeterFromRegistry" time="0.169" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="36" name="MultipleMetricsConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.299">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MultipleMetricsConstructorBeanTest" name="metricsConstructorCalled" time="0.299" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="37" name="MultipleMetricsMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.342">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MultipleMetricsMethodBeanTest" name="metricsMethodNotCalledYet" time="0.312" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MultipleMetricsMethodBeanTest" name="callMetricsMethodOnce" time="0.03" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="38" name="OverloadedTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.427">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.OverloadedTimedMethodBeanTest" name="overloadedTimedMethodNotCalledYet" time="0.391" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.OverloadedTimedMethodBeanTest" name="callOverloadedTimedMethodOnce" time="0.036" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="39" name="SimpleTimerFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.324">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerFieldBeanTest" name="simpleTimerFieldsWithDefaultNamingConvention" time="0.324" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="40" name="SimpleTimerFunctionalTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="109.212">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerFunctionalTest" name="testMinMaxEqual" time="109.212" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="41" name="SimpleTimerTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="1.425">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="testTime" time="1.344" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="testTimerRegistry" time="0.026" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="timesCallableInstances" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="timesRunnableInstances" time="0.027" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="42" name="SimplyTimedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.396">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedClassBeanTest" name="simplyTimedMethodsNotCalledYet" time="0.378" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedClassBeanTest" name="callSimplyTimedMethodsOnce" time="0.018" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="43" name="SimplyTimedConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.258">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedConstructorBeanTest" name="simpleTimerConstructorCalled" time="0.258" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="44" name="SimplyTimedMethodBeanLookupTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.615">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanLookupTest" name="simplyTimedMethodNotCalledYet" time="0.412" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanLookupTest" name="callSimplyTimedMethodOnce" time="2.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanLookupTest" name="removeSimplyTimedFromRegistry" time="0.167" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="45" name="SimplyTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.535">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanTest" name="simplyTimedMethodNotCalledYet" time="0.339" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanTest" name="callSimplyTimedMethodOnce" time="2.02" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanTest" name="removeSimpleTimerFromRegistry" time="0.176" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="46" name="TimedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.373">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedClassBeanTest" name="timedMethodsNotCalledYet" time="0.337" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedClassBeanTest" name="callTimedMethodsOnce" time="0.036" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="47" name="TimedConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.362">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedConstructorBeanTest" name="timedConstructorCalled" time="0.362" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="48" name="TimedMethodBeanLookupTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.733">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanLookupTest" name="timedMethodNotCalledYet" time="0.499" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanLookupTest" name="callTimedMethodOnce" time="2.039" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanLookupTest" name="removeTimerFromRegistry" time="0.195" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="49" name="TimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.605">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanTest" name="timedMethodNotCalledYet" time="0.398" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanTest" name="callTimedMethodOnce" time="2.034" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanTest" name="removeTimerFromRegistry" time="0.173" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="50" name="TimerFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.389">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerFieldBeanTest" name="timerFieldsWithDefaultNamingConvention" time="0.389" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="51" name="TimerTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="17" time="76.883">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot99thPercentile" time="0.338" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMax" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMin" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot98thPercentile" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMean" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotSize" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot95thPercentile" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMedian" time="0.026" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotStdDev" time="0.03" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotValues" time="0.029" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot999thPercentile" time="0.024" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot75thPercentile" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testRate" time="75.049" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testTime" time="1.022" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testTimerRegistry" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="timesCallableInstances" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="timesRunnableInstances" time="0.034" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="52" name="CounterFieldTagBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="2" time="0.38">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.CounterFieldTagBeanTest" name="counterTagFieldsRegistered" time="0.353" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.CounterFieldTagBeanTest" name="incrementCounterTagFields" time="0.027" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="53" name="GaugeTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="2" time="0.489">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.GaugeTagMethodBeanTest" name="gaugeTagCalledWithDefaultValue" time="0.456" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.GaugeTagMethodBeanTest" name="callGaugeTagAfterSetterCall" time="0.033" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="54" name="HistogramTagFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="2" time="0.321">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.HistogramTagFieldBeanTest" name="histogramTagFieldRegistered" time="0.281" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.HistogramTagFieldBeanTest" name="updateHistogramTagField" time="0.04" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="55" name="MeteredTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.36">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.MeteredTagMethodBeanTest" name="meteredTagMethodRegistered" time="0.36" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="56" name="SimplerTimerTagFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.358">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.SimplerTimerTagFieldBeanTest" name="simpleTimersTagFieldRegistered" time="0.358" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="57" name="SimplyTimedTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.361">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.SimplyTimedTagMethodBeanTest" name="simplyTimedTagMethodRegistered" time="0.361" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="58" name="TagsTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="8" time="0.618">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="simpleTagTest" time="0.35" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="lastTagValueTest" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="counterTagsTest" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="meterTagsTest" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="timerTagsTest" time="0.03" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="histogramTagsTest" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="simpleTimerTagsTest" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="concurrentGuageTagsTest" time="0.026" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="59" name="TimedTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.328">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TimedTagMethodBeanTest" name="timedTagMethodRegistered" time="0.328" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="60" name="TimerTagFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.343">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TimerTagFieldBeanTest" name="timersTagFieldRegistered" time="0.343" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="61" name="MpMetricTest" package="org.eclipse.microprofile.metrics.test" skipped="0" tests="47" time="7.407">
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationJsonResponseContentType" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testTextPlainResponseContentType" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBadSubTreeWillReturn404" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testListsAllJson" time="0.463" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBase" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseOpenMetrics" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseAttributeJson" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseSingularMetricsPresent" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseAttributeOpenMetrics" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadata" time="0.05" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataSingluarItems" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataTypeAndUnit" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testOpenMetricsFormatNoBadChars" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataSingluarItemsOpenMetrics" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataGarbageCollection" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetadataOkJson" time="0.024" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testSetupApplicationMetrics" time="1.309" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetricsJSON" time="1.178" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetadataItems" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetadataTypeAndUnit" time="0.103" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationTagJson" time="0.08" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationTagOpenMetrics" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMeterUnitOpenMetrics" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationTimerUnitOpenMetrics" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationHistogramUnitBytesOpenMetrics" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationHistogramUnitNoneOpenMetrics" time="0.07" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testOpenMetrics406ForOptions" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testConvertingToBaseUnit" time="0.124" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNonStandardUnitsJSON" time="0.05" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNonStandardUnitsOpenMetrics" time="0.05" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testOptionalBaseMetrics" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testSetupPromNoBadCharsInNames" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testPromNoBadCharsInNames" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept1" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept2" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept3" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept4" time="0.117" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept5" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNoAcceptHeader" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testCustomUnitAppendToGaugeName" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNoCustomUnitForCounter" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testGcCountMetrics" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testGcTimeMetrics" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testMultipleTaggedMetricsJSON" time="1.527" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testTranslateSemiColonToUnderScoreJSON" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationConcurrentGaugeOpenMetrics" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationSimpleTimerUnitOpenMetrics" time="0.048" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="62" name="ReusedMetricsTest" package="org.eclipse.microprofile.metrics.test" skipped="0" tests="4" time="0.804">
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="setA" time="0.425" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="testSharedCounter" time="0.244" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="setB" time="0.033" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="testSharedCounterAgain" time="0.102" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="63" name="MultipleBeanInstancesTest" package="org.eclipse.microprofile.metrics.test.multipleinstances" skipped="0" tests="3" time="0.605">
+      <testcase classname="org.eclipse.microprofile.metrics.test.multipleinstances.MultipleBeanInstancesTest" name="testMeter" time="0.523" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.multipleinstances.MultipleBeanInstancesTest" name="testTimer" time="0.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.multipleinstances.MultipleBeanInstancesTest" name="testCounter" time="0.046" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="64" name="MpMetricOptionalTest" package="org.eclipse.microprofile.metrics.test.optional" skipped="0" tests="20" time="19.936">
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTGet" time="4.282" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTGetExplicit" time="0.257" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTOptions" time="0.172" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTHead" time="0.197" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTPut" time="0.258" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTPost" time="0.231" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testDeleteNoParam" time="0.176" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetSingleParams" time="0.598" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetContextParams" time="0.246" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetListParam" time="0.358" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetMultiParam" time="0.307" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetNameObject" time="0.184" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetAsync" time="6.491" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testPostMultiParam" time="0.233" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testValidateGetJSONnoParam" time="1.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testValidateGetJSONParam" time="2.417" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetMappedArithException" time="0.562" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testPostMappedArithException" time="0.538" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetUnmappedArithException" time="0.871" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testPostUnmappedArithException" time="0.53" />
+  </testsuite>
+</testsuites>
+----
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" id="1" name="MetricFilterTest" package="org.eclipse.microprofile.metrics.tck" skipped="0" tests="1" time="0.231">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricFilterTest" name="theAllFilterMatchesAllMetrics" time="0.231" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="2" name="MetricIDTest" package="org.eclipse.microprofile.metrics.tck" skipped="0" tests="1" time="0.231">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricIDTest" name="removalTest" time="0.231" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="3" name="MetricRegistryTest" package="org.eclipse.microprofile.metrics.tck" skipped="0" tests="7" time="0.444">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="nameTest" time="0.273" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="registerTest" time="0.033" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="removeTest" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="useExistingMetaDataTest" time="0.025" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="testMetricRegistryType" time="0.021" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="sanitizeMetadataTest" time="0.019" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.MetricRegistryTest" name="conflictingMetadataTest" time="0.035" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="4" name="ApplicationScopedTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="0.498">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.ApplicationScopedTimedMethodBeanTest" name="timedMethodNotCalledYet" time="0.465" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.ApplicationScopedTimedMethodBeanTest" name="callTimedMethodOnce" time="0.033" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="5" name="GaugeInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="0.417">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.GaugeInjectionBeanTest" name="gaugeCalledWithDefaultValue" time="0.387" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.GaugeInjectionBeanTest" name="callGaugeAfterSetterCall" time="0.03" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="6" name="MeterInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="0.28">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.MeterInjectionBeanTest" name="meteredMethodNotCalledYet" time="0.247" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.MeterInjectionBeanTest" name="callMeteredMethodOnce" time="0.033" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="7" name="SimpleTimerInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="2.421">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.SimpleTimerInjectionBeanTest" name="simplyTimedMethodNotCalledYet" time="0.341" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.SimpleTimerInjectionBeanTest" name="callSimplyTimedMethodOnce" time="2.08" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="8" name="TimerInjectionBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi" skipped="0" tests="2" time="2.411">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.TimerInjectionBeanTest" name="timedMethodNotCalledYet" time="0.37" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.TimerInjectionBeanTest" name="callTimedMethodOnce" time="2.041" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="9" name="StereotypeCountedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.cdi.stereotype" skipped="0" tests="2" time="0.299">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.stereotype.StereotypeCountedClassBeanTest" name="testWithMetadata" time="0.275" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.cdi.stereotype.StereotypeCountedClassBeanTest" name="testPlainAnnotation" time="0.024" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="10" name="InheritedGaugeMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.3">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedGaugeMethodBeanTest" name="gaugesCalledWithDefaultValues" time="0.282" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedGaugeMethodBeanTest" name="callGaugesAfterSetterCalls" time="0.018" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="11" name="InheritedSimplyTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.287">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedSimplyTimedMethodBeanTest" name="simplyTimedMethodsNotCalledYet" time="0.259" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedSimplyTimedMethodBeanTest" name="callSimplyTimedMethodsOnce" time="0.028" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="12" name="InheritedTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.287">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedTimedMethodBeanTest" name="timedMethodsNotCalledYet" time="0.242" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.InheritedTimedMethodBeanTest" name="callTimedMethodsOnce" time="0.045" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="13" name="VisibilitySimplyTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.309">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilitySimplyTimedMethodBeanTest" name="simplyTimedMethodsNotCalledYet" time="0.286" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilitySimplyTimedMethodBeanTest" name="callSimplyTimedMethodsOnce" time="0.023" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="14" name="VisibilityTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.inheritance" skipped="0" tests="2" time="0.275">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilityTimedMethodBeanTest" name="timedMethodsNotCalledYet" time="0.242" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.inheritance.VisibilityTimedMethodBeanTest" name="callTimedMethodsOnce" time="0.033" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="15" name="ConcreteExtendedTimedBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.346">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="timedMethodNotCalledYet" time="0.244" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="extendedTimedMethodNotCalledYet" time="0.035" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="callTimedMethodOnce" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteExtendedTimedBeanTest" name="callExtendedTimedMethodOnce" time="0.026" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="16" name="ConcreteTimedBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.371">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="timedMethodNotCalledYet" time="0.287" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="extendedTimedMethodNotCalledYet" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="callTimedMethodOnce" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcreteTimedBeanTest" name="callExtendedTimedMethodOnce" time="0.022" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="17" name="ConcurrentGaugeFunctionalTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="101.471">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeFunctionalTest" name="testMinMax" time="101.407" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeFunctionalTest" name="testConcurrentInvocations" time="0.064" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="18" name="ConcurrentGaugeTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="0.275">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeTest" name="getCountTest" time="0.229" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeTest" name="incrementTest" time="0.022" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugeTest" name="decrementTest" time="0.024" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="19" name="ConcurrentGaugedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.33">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedClassBeanTest" name="countedMethodsNotCalledYet" time="0.294" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedClassBeanTest" name="callCountedMethodsOnce" time="0.036" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="20" name="ConcurrentGaugedConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.246">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedConstructorBeanTest" name="countedConstructorCalled" time="0.246" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="21" name="ConcurrentGaugedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.547">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="countedMethodNotCalledYet" time="0.31" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="metricInjectionIntoTest" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="callCountedMethodOnce" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.ConcurrentGaugedMethodBeanTest" name="removeCounterFromRegistry" time="0.14" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="22" name="CountedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.271">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedClassBeanTest" name="countedMethodsNotCalledYet" time="0.246" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedClassBeanTest" name="callCountedMethodsOnce" time="0.025" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="23" name="CountedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="0.345">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="countedMethodNotCalledYet" time="0.226" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="metricInjectionIntoTest" time="0.022" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="callCountedMethodOnce" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodBeanTest" name="removeCounterFromRegistry" time="0.069" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="24" name="CountedMethodTagBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.22">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodTagBeanTest" name="counterTagMethodsRegistered" time="0.194" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CountedMethodTagBeanTest" name="countedTagMethodNotCalledYet" time="0.026" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="25" name="CounterFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.259">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterFieldBeanTest" name="counterFieldRegistered" time="0.231" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterFieldBeanTest" name="incrementCounterField" time="0.028" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="26" name="CounterTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="0.319">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterTest" name="getCountTest" time="0.235" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterTest" name="incrementTest" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.CounterTest" name="incrementLongTest" time="0.043" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="27" name="DefaultNameMetricMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.214">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.DefaultNameMetricMethodBeanTest" name="metricMethodsWithDefaultNamingConvention" time="0.214" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="28" name="GaugeMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.402">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.GaugeMethodBeanTest" name="gaugeCalledWithDefaultValue" time="0.375" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.GaugeMethodBeanTest" name="callGaugeAfterSetterCall" time="0.027" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="29" name="GaugeTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.3">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.GaugeTest" name="testManualGauge" time="0.3" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="30" name="HistogramFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.311">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramFieldBeanTest" name="histogramFieldRegistered" time="0.293" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramFieldBeanTest" name="updateHistogramField" time="0.018" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="31" name="HistogramTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="15" time="0.642">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSum" time="0.26" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testCount" time="0.026" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot99thPercentile" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMax" time="0.024" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMin" time="0.033" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot98thPercentile" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMean" time="0.015" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotSize" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot95thPercentile" time="0.017" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testMetricRegistry" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotMedian" time="0.021" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotStdDev" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshotValues" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot999thPercentile" time="0.013" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.HistogramTest" name="testSnapshot75thPercentile" time="0.019" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="32" name="MeterTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="75.317">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeterTest" name="testCount" time="0.255" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeterTest" name="testRates" time="75.062" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="33" name="MeteredClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.31">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredClassBeanTest" name="meteredMethodsNotCalledYet" time="0.277" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredClassBeanTest" name="callMeteredMethodsOnce" time="0.033" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="34" name="MeteredConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.3">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredConstructorBeanTest" name="meteredConstructorCalled" time="0.3" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="35" name="MeteredMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="0.363">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredMethodBeanTest" name="meteredMethodNotCalledYet" time="0.261" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredMethodBeanTest" name="callMeteredMethodOnce" time="0.032" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MeteredMethodBeanTest" name="removeMeterFromRegistry" time="0.07" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="36" name="MultipleMetricsConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.279">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MultipleMetricsConstructorBeanTest" name="metricsConstructorCalled" time="0.279" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="37" name="MultipleMetricsMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.306">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MultipleMetricsMethodBeanTest" name="metricsMethodNotCalledYet" time="0.248" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.MultipleMetricsMethodBeanTest" name="callMetricsMethodOnce" time="0.058" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="38" name="OverloadedTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.386">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.OverloadedTimedMethodBeanTest" name="overloadedTimedMethodNotCalledYet" time="0.372" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.OverloadedTimedMethodBeanTest" name="callOverloadedTimedMethodOnce" time="0.014" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="39" name="SimpleTimerFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.225">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerFieldBeanTest" name="simpleTimerFieldsWithDefaultNamingConvention" time="0.225" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="40" name="SimpleTimerFunctionalTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="61.743">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerFunctionalTest" name="testMinMaxEqual" time="61.743" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="41" name="SimpleTimerTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="4" time="1.315">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="testTime" time="1.245" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="testTimerRegistry" time="0.025" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="timesCallableInstances" time="0.03" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimpleTimerTest" name="timesRunnableInstances" time="0.015" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="42" name="SimplyTimedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.314">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedClassBeanTest" name="simplyTimedMethodsNotCalledYet" time="0.283" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedClassBeanTest" name="callSimplyTimedMethodsOnce" time="0.031" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="43" name="SimplyTimedConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.323">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedConstructorBeanTest" name="simpleTimerConstructorCalled" time="0.323" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="44" name="SimplyTimedMethodBeanLookupTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.415">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanLookupTest" name="simplyTimedMethodNotCalledYet" time="0.294" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanLookupTest" name="callSimplyTimedMethodOnce" time="2.041" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanLookupTest" name="removeSimplyTimedFromRegistry" time="0.08" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="45" name="SimplyTimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.443">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanTest" name="simplyTimedMethodNotCalledYet" time="0.283" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanTest" name="callSimplyTimedMethodOnce" time="2.046" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.SimplyTimedMethodBeanTest" name="removeSimpleTimerFromRegistry" time="0.114" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="46" name="TimedClassBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="2" time="0.279">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedClassBeanTest" name="timedMethodsNotCalledYet" time="0.251" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedClassBeanTest" name="callTimedMethodsOnce" time="0.028" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="47" name="TimedConstructorBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.341">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedConstructorBeanTest" name="timedConstructorCalled" time="0.341" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="48" name="TimedMethodBeanLookupTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.459">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanLookupTest" name="timedMethodNotCalledYet" time="0.306" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanLookupTest" name="callTimedMethodOnce" time="2.027" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanLookupTest" name="removeTimerFromRegistry" time="0.126" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="49" name="TimedMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="3" time="2.381">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanTest" name="timedMethodNotCalledYet" time="0.253" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanTest" name="callTimedMethodOnce" time="2.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimedMethodBeanTest" name="removeTimerFromRegistry" time="0.092" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="50" name="TimerFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="1" time="0.252">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerFieldBeanTest" name="timerFieldsWithDefaultNamingConvention" time="0.252" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="51" name="TimerTest" package="org.eclipse.microprofile.metrics.tck.metrics" skipped="0" tests="17" time="76.808">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot99thPercentile" time="0.243" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMax" time="0.024" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMin" time="0.03" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot98thPercentile" time="0.02" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMean" time="0.031" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotSize" time="0.04" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot95thPercentile" time="0.023" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotMedian" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotStdDev" time="0.027" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshotValues" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot999thPercentile" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testSnapshot75thPercentile" time="0.037" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testRate" time="75.076" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testTime" time="1.036" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="testTimerRegistry" time="0.028" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="timesCallableInstances" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.metrics.TimerTest" name="timesRunnableInstances" time="0.025" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="52" name="CounterFieldTagBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="2" time="0.237">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.CounterFieldTagBeanTest" name="counterTagFieldsRegistered" time="0.215" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.CounterFieldTagBeanTest" name="incrementCounterTagFields" time="0.022" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="53" name="GaugeTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="2" time="0.288">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.GaugeTagMethodBeanTest" name="gaugeTagCalledWithDefaultValue" time="0.258" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.GaugeTagMethodBeanTest" name="callGaugeTagAfterSetterCall" time="0.03" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="54" name="HistogramTagFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="2" time="0.286">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.HistogramTagFieldBeanTest" name="histogramTagFieldRegistered" time="0.251" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.HistogramTagFieldBeanTest" name="updateHistogramTagField" time="0.035" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="55" name="MeteredTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.221">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.MeteredTagMethodBeanTest" name="meteredTagMethodRegistered" time="0.221" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="56" name="SimplerTimerTagFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.255">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.SimplerTimerTagFieldBeanTest" name="simpleTimersTagFieldRegistered" time="0.255" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="57" name="SimplyTimedTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.26">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.SimplyTimedTagMethodBeanTest" name="simplyTimedTagMethodRegistered" time="0.26" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="58" name="TagsTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="8" time="0.439">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="simpleTagTest" time="0.235" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="lastTagValueTest" time="0.027" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="counterTagsTest" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="meterTagsTest" time="0.023" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="timerTagsTest" time="0.02" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="histogramTagsTest" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="simpleTimerTagsTest" time="0.033" />
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TagsTest" name="concurrentGuageTagsTest" time="0.018" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="59" name="TimedTagMethodBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.277">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TimedTagMethodBeanTest" name="timedTagMethodRegistered" time="0.277" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="60" name="TimerTagFieldBeanTest" package="org.eclipse.microprofile.metrics.tck.tags" skipped="0" tests="1" time="0.265">
+      <testcase classname="org.eclipse.microprofile.metrics.tck.tags.TimerTagFieldBeanTest" name="timersTagFieldRegistered" time="0.265" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="61" name="MpMetricTest" package="org.eclipse.microprofile.metrics.test" skipped="0" tests="47" time="7.984">
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationJsonResponseContentType" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testTextPlainResponseContentType" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBadSubTreeWillReturn404" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testListsAllJson" time="0.495" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBase" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseOpenMetrics" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseAttributeJson" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseSingularMetricsPresent" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseAttributeOpenMetrics" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadata" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataSingluarItems" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataTypeAndUnit" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testOpenMetricsFormatNoBadChars" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataSingluarItemsOpenMetrics" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testBaseMetadataGarbageCollection" time="0.16" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetadataOkJson" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testSetupApplicationMetrics" time="1.227" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetricsJSON" time="1.286" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetadataItems" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMetadataTypeAndUnit" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationTagJson" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationTagOpenMetrics" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationMeterUnitOpenMetrics" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationTimerUnitOpenMetrics" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationHistogramUnitBytesOpenMetrics" time="0.138" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationHistogramUnitNoneOpenMetrics" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testOpenMetrics406ForOptions" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testConvertingToBaseUnit" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNonStandardUnitsJSON" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNonStandardUnitsOpenMetrics" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testOptionalBaseMetrics" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testSetupPromNoBadCharsInNames" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testPromNoBadCharsInNames" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept1" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept2" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept3" time="0.06" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept4" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testAccept5" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNoAcceptHeader" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testCustomUnitAppendToGaugeName" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testNoCustomUnitForCounter" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testGcCountMetrics" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testGcTimeMetrics" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testMultipleTaggedMetricsJSON" time="1.567" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testTranslateSemiColonToUnderScoreJSON" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationConcurrentGaugeOpenMetrics" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.MpMetricTest" name="testApplicationSimpleTimerUnitOpenMetrics" time="0.064" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="62" name="ReusedMetricsTest" package="org.eclipse.microprofile.metrics.test" skipped="0" tests="4" time="0.818">
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="setA" time="0.456" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="testSharedCounter" time="0.185" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="setB" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.ReusedMetricsTest" name="testSharedCounterAgain" time="0.139" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="63" name="MultipleBeanInstancesTest" package="org.eclipse.microprofile.metrics.test.multipleinstances" skipped="0" tests="3" time="0.572">
+      <testcase classname="org.eclipse.microprofile.metrics.test.multipleinstances.MultipleBeanInstancesTest" name="testMeter" time="0.482" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.multipleinstances.MultipleBeanInstancesTest" name="testTimer" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.multipleinstances.MultipleBeanInstancesTest" name="testCounter" time="0.052" />
+  </testsuite>
+  <testsuite errors="0" failures="0" id="64" name="MpMetricOptionalTest" package="org.eclipse.microprofile.metrics.test.optional" skipped="0" tests="20" time="17.842">
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTGet" time="3.117" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTGetExplicit" time="0.166" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTOptions" time="0.154" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTHead" time="0.181" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTPut" time="0.147" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testSimpleRESTPost" time="0.231" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testDeleteNoParam" time="0.158" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetSingleParams" time="0.562" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetContextParams" time="0.173" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetListParam" time="0.263" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetMultiParam" time="0.27" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetNameObject" time="0.145" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetAsync" time="6.474" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testPostMultiParam" time="0.288" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testValidateGetJSONnoParam" time="0.818" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testValidateGetJSONParam" time="2.173" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetMappedArithException" time="0.579" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testPostMappedArithException" time="0.553" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testGetUnmappedArithException" time="0.704" />
+      <testcase classname="org.eclipse.microprofile.metrics.test.optional.MpMetricOptionalTest" name="testPostUnmappedArithException" time="0.686" />
+  </testsuite>
+</testsuites>
+----

--- a/microprofile/4.1/mpjwt/1.2/TCKResults.adoc
+++ b/microprofile/4.1/mpjwt/1.2/TCKResults.adoc
@@ -1,0 +1,1002 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Interoperable JWT RBAC 1.2.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile Interoperable JWT RBAC 1.2 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-jwt-auth-1.2/microprofile-jwt-auth-spec-1.2.html[MicroProfile Interoperable JWT RBAC 1.2]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+RHEL 8
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="0" name="FATSuite" package="com.ibm.ws.microprofile.mpjwt12.tck" tests="6" time="466.366" timestamp="2021-07-03T07:24:51">
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_env" name="launchMpjwt12TCKLauncher_aud_env" time="188.411" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv" name="launchMpjwt12TCKLauncher_aud_noenv" time="95.601" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_env" name="launchMpjwt12TCKLauncher_noaud_env" time="35.633" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_noenv" name="launchMpjwt12TCKLauncher_noaud_noenv" time="41.235" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv2" name="launchMpjwt12TCKLauncher_aud_noenv2" time="23.461" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.DummyForQuarantine" name="alwaysPass" time="0.001" />
+
+      <system-err />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="1" name="ECPublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.392" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.392" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="2" name="ECPublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.206" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="0.206" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="3" name="ECPublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.259" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" name="testKeyAsPEM" time="0.259" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="4" name="IssValidationFailTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="4.428" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" name="testNotRequiredIssMismatchFailure" time="4.428" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="5" name="IssValidationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="2.492" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" name="testRequiredIss" time="2.492" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="6" name="PublicKeyAsBase64JWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.352" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" name="testKeyAsBase64JWK" time="0.352" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="7" name="PublicKeyAsFileLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.343" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" name="testKeyAsLocationUrl" time="0.343" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="8" name="PublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.389" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.389" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="9" name="PublicKeyAsJWKLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="6.846" timestamp="3 Jul 2021 07:32:33 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="validateLocationUrlContents" time="3.245" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="testKeyAsLocationUrl" time="3.601" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="10" name="PublicKeyAsJWKSLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.529" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" name="testKeyAsLocation" time="0.529" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="11" name="PublicKeyAsJWKSTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.364" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" name="testKeyAsJWKS" time="0.364" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="12" name="PublicKeyAsJWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.392" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" name="testKeyAsJWK" time="0.392" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="13" name="PublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="6.552" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="6.552" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="14" name="PublicKeyAsPEMLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.726" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="testKeyAsLocationUrl" time="0.480" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="validateLocationUrlContents" time="0.246" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="15" name="PublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.402" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" name="testKeyAsPEM" time="0.402" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="16" name="TokenAsCookieIgnoredTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.523" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="noTokenHeaderSetToCookie" time="0.309" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="validJwt" time="0.214" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="17" name="TokenAsCookieTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.274" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" name="validJwt" time="0.274" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="18" name="PrivateKeyAsJWKClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.370" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" name="testKeyAsLocation" time="0.370" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="19" name="PrivateKeyAsJWKSClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.443" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" name="testKeyAsLocation" time="0.443" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="20" name="PrivateKeyAsPEMClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.453" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" name="testKeyAsLocationResource" time="0.453" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="21" name="ApplicationScopedInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.839" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenClaimValue" time="0.230" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawToken1Provider" time="0.360" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenJwt" time="0.249" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="22" name="AudArrayValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="1.619" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" name="testRequiredAudMatch" time="1.619" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="23" name="AudValidationBadAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.180" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" name="testRequiredAudMismatchFailure" time="0.180" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="24" name="AudValidationMissingAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.192" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" name="testRequiredAudMissingFailure" time="0.192" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="25" name="AudValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.373" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" name="testRequiredAudMatch" time="0.373" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="26" name="ClaimValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="19" time="8.188" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalSubject" time="0.182" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTIStandard" time="0.154" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.142" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudience" time="5.340" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudienceStandard" time="0.179" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomDouble" time="0.156" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomInteger" time="0.167" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAt" time="0.156" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomBoolean" time="0.166" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomString" time="0.169" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawToken" time="0.149" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.161" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedSubjectStandard" time="0.128" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAuthTimeStandard" time="0.178" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawTokenStandard" time="0.149" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerClaim" time="0.152" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAtStandard" time="0.160" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerStandardClaim" time="0.141" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTI" time="0.159" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="27" name="CookieTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="5" time="0.739" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="expiredCookie" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="ignoreHeaderIfCookieSet" time="0.163" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="emptyCookie" time="0.063" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="wrongCookieName" time="0.121" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="validCookieJwt" time="0.265" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="28" name="EmptyTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.439" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="invalidToken" time="0.116" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="emptyToken" time="0.117" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="validToken" time="0.206" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="29" name="InvalidTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="4" time="1.126" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadIssuer" time="0.300" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSigner" time="0.567" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSignerAlg" time="0.143" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoExpiredToken" time="0.116" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="30" name="JsonValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.428" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime" time="0.149" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble" time="0.144" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDoubleArray" time="0.163" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString" time="0.121" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString2" time="0.163" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger2" time="0.163" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken" time="0.149" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomStringArray" time="0.133" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomIntegerArray" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience" time="0.270" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience2" time="0.229" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime2" time="0.192" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt" time="0.138" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim" time="0.137" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble2" time="0.208" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken2" time="0.175" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim2" time="0.152" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI2" time="0.188" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI" time="0.123" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger" time="0.137" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt2" time="0.170" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="31" name="PrimitiveInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="1.357" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyIssuerClaim" time="0.125" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedJTI" time="0.100" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedGroups" time="0.100" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedUPN" time="0.114" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedExpiration" time="0.095" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomString" time="0.104" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedAudience" time="0.277" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomBoolean" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedIssuedAt" time="0.098" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedSUB" time="0.105" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedRawToken" time="0.115" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="32" name="PrincipalInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.298" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" name="verifyInjectedPrincipal" time="0.298" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="33" name="ProviderInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="2.784" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim" time="0.136" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble" time="0.183" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.109" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger2" time="0.146" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim2" time="0.159" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt2" time="0.125" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject" time="0.105" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt" time="0.122" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime2" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble2" time="0.114" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience2" time="0.133" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString2" time="0.112" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI" time="0.116" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.140" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken2" time="0.107" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString" time="0.130" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI2" time="0.153" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger" time="0.116" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject2" time="0.105" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience" time="0.222" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="34" name="RequiredClaimsTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="2.310" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuedAt" time="0.167" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyOptionalAudience" time="0.332" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyJTI" time="0.177" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithIatOlderThanExp" time="0.260" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyUPN" time="0.131" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifySubClaim" time="0.200" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutExpiration" time="0.162" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutName" time="0.204" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyExpiration" time="0.191" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyAudience" time="0.257" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuerClaim" time="0.229" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="35" name="RolesAllowedTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="15" time="1.597" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho2" time="0.137" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoGroups" time="0.122" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRoleToken2" time="0.136" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoAuth" time="0.054" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoNeedsToken2Role" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getInjectedPrincipal" time="0.093" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="noTokenHeaderSetToCookie" time="0.111" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho" time="0.205" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignToken" time="0.090" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoWithToken2" time="0.114" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callHeartbeat" time="0.049" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignEncryptToken" time="0.074" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRole" time="0.133" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getPrincipalClass" time="0.102" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoBASIC" time="0.051" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="36" name="RsaKeySignatureTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.295" timestamp="3 Jul 2021 07:30:05 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" name="callEcho" time="0.295" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="37" name="UnsecuredPingTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="3.956" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" name="callEchoNoAuth" time="3.956" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="38" name="RolesAllowedSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe" tests="14" time="2.187" timestamp="3 Jul 2021 07:28:13 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho" time="0.197" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignToken" time="0.158" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoNeedsToken2Role" time="0.265" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callHeartbeat" time="0.047" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoWithoutCty" time="0.232" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRoleToken2" time="0.393" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoWithToken2" time="0.304" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRole" time="0.110" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignEncryptToken" time="0.102" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho2" time="0.100" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoBASIC" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getPrincipalClass" time="0.099" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getInjectedPrincipal" time="0.114" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoNoAuth" time="0.034" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="39" name="TokenUtilsEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="8" time="1.147" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailAlgorithm" time="0.015" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailExpired" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidateSignedToken" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailEncryption" time="0.970" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidToken" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testExpGrace" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailJustExpired" time="0.021" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailIssuer" time="0.021" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="40" name="TokenUtilsSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="7" time="0.433" timestamp="3 Jul 2021 07:31:54 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptECSignedClaims" time="0.167" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaims" time="0.068" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaimsWithoutCty" time="0.064" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateSignedToken" time="0.018" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByRSKeyVerifiedByECKey" time="0.050" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByECKeyVerifiedByRSKey" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateEncryptedOnlyToken" time="0.026" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2082qmwkyqt-n.fyre.ibm.com" id="41" name="TokenUtilsTest" package="org.eclipse.microprofile.jwt.tck.util" tests="18" time="2.614" timestamp="3 Jul 2021 07:30:57 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByECKeyVerifiedByRSKey" time="0.132" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignature" time="0.413" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGrace" time="0.855" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenDeprecated" time="0.021" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithmDeprecated" time="0.007" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpired" time="0.045" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuerDeprecated" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuer" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpired" time="0.025" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken1024BitKeyLength" time="0.056" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpiredDeprecated" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignatureDeprecated" time="0.818" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpiredDeprecated" time="0.020" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenEC256" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByRSKeyVerifiedByECKey" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithm" time="0.016" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGraceDeprecated" time="0.027" />
+
+  </testsuite>
+</testsuites>
+----
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="0" name="FATSuite" package="com.ibm.ws.microprofile.mpjwt12.tck" tests="6" time="648.411" timestamp="2021-07-03T07:37:45">
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_env" name="launchMpjwt12TCKLauncher_aud_env" time="353.26" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv" name="launchMpjwt12TCKLauncher_aud_noenv" time="95.514" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_env" name="launchMpjwt12TCKLauncher_noaud_env" time="34.981" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_noaud_noenv" name="launchMpjwt12TCKLauncher_noaud_noenv" time="40.157" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.Mpjwt12TCKLauncher_aud_noenv2" name="launchMpjwt12TCKLauncher_aud_noenv2" time="22.108" />
+
+      <testcase classname="com.ibm.ws.microprofile.mpjwt12.tck.DummyForQuarantine" name="alwaysPass" time="0.001" />
+
+      <system-err><![CDATA[]]></system-err>
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="1" name="ECPublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.479" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.479" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="2" name="ECPublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.391" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="0.391" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="3" name="ECPublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.293" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" name="testKeyAsPEM" time="0.293" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="4" name="IssValidationFailTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="5.808" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" name="testNotRequiredIssMismatchFailure" time="5.808" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="5" name="IssValidationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="3.086" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" name="testRequiredIss" time="3.086" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="6" name="PublicKeyAsBase64JWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.332" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" name="testKeyAsBase64JWK" time="0.332" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="7" name="PublicKeyAsFileLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.363" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" name="testKeyAsLocationUrl" time="0.363" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="8" name="PublicKeyAsJWKLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.334" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" name="testKeyAsLocation" time="0.334" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="9" name="PublicKeyAsJWKLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="7.698" timestamp="3 Jul 2021 07:48:29 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="validateLocationUrlContents" time="4.391" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" name="testKeyAsLocationUrl" time="3.307" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="10" name="PublicKeyAsJWKSLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.530" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" name="testKeyAsLocation" time="0.530" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="11" name="PublicKeyAsJWKSTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.348" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" name="testKeyAsJWKS" time="0.348" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="12" name="PublicKeyAsJWKTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.393" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" name="testKeyAsJWK" time="0.393" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="13" name="PublicKeyAsPEMLocationTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="7.246" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" name="testKeyAsLocationResource" time="7.246" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="14" name="PublicKeyAsPEMLocationURLTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="1.091" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="validateLocationUrlContents" time="0.296" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" name="testKeyAsLocationUrl" time="0.795" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="15" name="PublicKeyAsPEMTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.476" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" name="testKeyAsPEM" time="0.476" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="16" name="TokenAsCookieIgnoredTest" package="org.eclipse.microprofile.jwt.tck.config" tests="2" time="0.642" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="noTokenHeaderSetToCookie" time="0.418" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" name="validJwt" time="0.224" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="17" name="TokenAsCookieTest" package="org.eclipse.microprofile.jwt.tck.config" tests="1" time="0.340" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" name="validJwt" time="0.340" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="18" name="PrivateKeyAsJWKClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.281" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" name="testKeyAsLocation" time="0.281" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="19" name="PrivateKeyAsJWKSClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.255" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" name="testKeyAsLocation" time="0.255" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="20" name="PrivateKeyAsPEMClasspathTest" package="org.eclipse.microprofile.jwt.tck.config.jwe" tests="1" time="0.274" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" name="testKeyAsLocationResource" time="0.274" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="21" name="ApplicationScopedInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="1.025" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenClaimValue" time="0.244" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawTokenJwt" time="0.253" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" name="verifyInjectedRawToken1Provider" time="0.528" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="22" name="AudArrayValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="2.210" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" name="testRequiredAudMatch" time="2.210" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="23" name="AudValidationBadAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.160" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" name="testRequiredAudMismatchFailure" time="0.160" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="24" name="AudValidationMissingAudTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.261" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" name="testRequiredAudMissingFailure" time="0.261" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="25" name="AudValidationTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.416" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" name="testRequiredAudMatch" time="0.416" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="26" name="ClaimValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="19" time="11.212" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAtStandard" time="0.261" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudienceStandard" time="0.271" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTI" time="0.192" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedJTIStandard" time="0.201" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomDouble" time="0.224" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomString" time="0.191" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedSubjectStandard" time="0.197" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawToken" time="0.211" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedIssuedAt" time="0.222" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomBoolean" time="0.218" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerClaim" time="0.205" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAuthTimeStandard" time="0.257" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyIssuerStandardClaim" time="0.186" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedCustomInteger" time="0.207" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.166" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.183" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedAudience" time="7.393" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedRawTokenStandard" time="0.206" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" name="verifyInjectedOptionalSubject" time="0.221" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="27" name="CookieTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="5" time="0.790" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="ignoreHeaderIfCookieSet" time="0.169" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="emptyCookie" time="0.110" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="wrongCookieName" time="0.084" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="validCookieJwt" time="0.316" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" name="expiredCookie" time="0.111" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="28" name="EmptyTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="3" time="0.551" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="emptyToken" time="0.227" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="invalidToken" time="0.135" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" name="validToken" time="0.189" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="29" name="InvalidTokenTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="4" time="1.521" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoExpiredToken" time="0.094" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadIssuer" time="0.349" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSignerAlg" time="0.108" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" name="callEchoBadSigner" time="0.970" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="30" name="JsonValueInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.814" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger2" time="0.173" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomIntegerArray" time="0.161" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI" time="0.149" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble2" time="0.198" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDoubleArray" time="0.229" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime" time="0.198" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim2" time="0.182" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken" time="0.152" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString2" time="0.161" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomInteger" time="0.180" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyIssuerClaim" time="0.162" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAuthTime2" time="0.194" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedRawToken2" time="0.166" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomStringArray" time="0.142" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomString" time="0.163" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedJTI2" time="0.170" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience2" time="0.183" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt" time="0.142" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedIssuedAt2" time="0.165" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedCustomDouble" time="0.160" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" name="verifyInjectedAudience" time="0.384" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="31" name="PrimitiveInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="1.915" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedRawToken" time="0.155" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedJTI" time="0.164" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedUPN" time="0.139" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyIssuerClaim" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedExpiration" time="0.183" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomString" time="0.173" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedCustomBoolean" time="0.214" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedSUB" time="0.141" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedAudience" time="0.339" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedGroups" time="0.138" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" name="verifyInjectedIssuedAt" time="0.142" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="32" name="PrincipalInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.401" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" name="verifyInjectedPrincipal" time="0.401" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="33" name="ProviderInjectionTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="21" time="3.604" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime" time="0.116" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim" time="0.152" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt2" time="0.153" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI2" time="0.128" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken" time="0.121" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble2" time="0.154" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger2" time="0.179" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience" time="0.454" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedIssuedAt" time="0.145" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomDouble" time="0.154" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString" time="0.129" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject2" time="0.157" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalSubject" time="0.136" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedJTI" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalCustomMissing" time="0.205" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedOptionalAuthTime2" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomInteger" time="0.284" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedRawToken2" time="0.134" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedCustomString2" time="0.176" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyIssuerClaim2" time="0.198" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" name="verifyInjectedAudience2" time="0.178" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="34" name="RequiredClaimsTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="11" time="2.192" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyUPN" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutExpiration" time="0.201" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyAudience" time="0.360" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifySubClaim" time="0.197" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithoutName" time="0.150" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyExpiration" time="0.160" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyTokenWithIatOlderThanExp" time="0.396" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuedAt" time="0.165" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyJTI" time="0.171" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyOptionalAudience" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" name="verifyIssuerClaim" time="0.140" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="35" name="RolesAllowedTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="15" time="2.307" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callHeartbeat" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoAuth" time="0.115" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho" time="0.304" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignEncryptToken" time="0.090" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoNeedsToken2Role" time="0.126" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEcho2" time="0.112" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoBASIC" time="0.065" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRoleToken2" time="0.130" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="checkIsUserInRole" time="0.140" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getInjectedPrincipal" time="0.129" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="noTokenHeaderSetToCookie" time="0.606" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoNoGroups" time="0.104" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="echoWithToken2" time="0.124" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="getPrincipalClass" time="0.113" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" name="callEchoSignToken" time="0.112" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="36" name="RsaKeySignatureTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="0.422" timestamp="3 Jul 2021 07:45:52 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" name="callEcho" time="0.422" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="37" name="UnsecuredPingTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs" tests="1" time="4.425" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" name="callEchoNoAuth" time="4.425" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="38" name="RolesAllowedSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe" tests="14" time="1.444" timestamp="3 Jul 2021 07:43:56 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho" time="0.270" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoWithoutCty" time="0.094" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoNeedsToken2Role" time="0.132" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRoleToken2" time="0.128" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getPrincipalClass" time="0.123" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="getInjectedPrincipal" time="0.104" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="checkIsUserInRole" time="0.143" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignEncryptToken" time="0.071" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callHeartbeat" time="0.033" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoSignToken" time="0.070" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoBASIC" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEcho2" time="0.096" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="callEchoNoAuth" time="0.035" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" name="echoWithToken2" time="0.106" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="39" name="TokenUtilsEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="8" time="0.761" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailIssuer" time="0.007" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailAlgorithm" time="0.009" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidToken" time="0.007" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailEncryption" time="0.665" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testExpGrace" time="0.017" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailJustExpired" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testFailExpired" time="0.041" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" name="testValidateSignedToken" time="0.007" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="40" name="TokenUtilsSignEncryptTest" package="org.eclipse.microprofile.jwt.tck.util" tests="7" time="0.167" timestamp="3 Jul 2021 07:47:47 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateEncryptedOnlyToken" time="0.006" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByRSKeyVerifiedByECKey" time="0.013" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaims" time="0.014" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testValidateSignedToken" time="0.005" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptECSignedClaims" time="0.082" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testEncryptSignedClaimsWithoutCty" time="0.011" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" name="testNestedSignedByECKeyVerifiedByRSKey" time="0.036" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1689qmypp29-n.fyre.ibm.com" id="41" name="TokenUtilsTest" package="org.eclipse.microprofile.jwt.tck.util" tests="18" time="2.599" timestamp="3 Jul 2021 07:46:48 GMT">
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken" time="0.007" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpiredDeprecated" time="0.014" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGraceDeprecated" time="0.013" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithm" time="0.015" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignatureDeprecated" time="0.893" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByECKeyVerifiedByRSKey" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testSignedByRSKeyVerifiedByECKey" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailAlgorithmDeprecated" time="0.006" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidToken1024BitKeyLength" time="0.248" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuer" time="0.009" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenDeprecated" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpiredDeprecated" time="0.010" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailSignature" time="1.034" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailIssuerDeprecated" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testExpGrace" time="0.237" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailJustExpired" time="0.008" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testFailExpired" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" name="testValidTokenEC256" time="0.018" />
+
+  </testsuite>
+</testsuites>
+----

--- a/microprofile/4.1/openapi/2.0/TCKResults.adoc
+++ b/microprofile/4.1/openapi/2.0/TCKResults.adoc
@@ -1,0 +1,594 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Open API 2.0.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile Open API 2.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-open-api-2.0/microprofile-openapi-spec-2.0.html[MicroProfile Open API 2.0]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+RHEL 8
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="1" name="AirlinesAppTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="94" time="16.046" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagDeclarations" time="0.273" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testComponents" time="0.257" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInAPIResponse" time="0.309" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testServer" time="0.460" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testInfo" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testStaticFileDefinitions" time="0.436" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInRequestBody" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAirlinesResource" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testVersion" time="0.034" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInComponents" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityScheme" time="0.129" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingRequestBody" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExampleObject" time="0.127" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInEncoding" time="0.107" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testStaticFileDefinitions" time="0.352" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExplode" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationUserResource" time="0.356" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExceptionMappers" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInAPIResponse" time="0.281" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRestClientNotPickedUp" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testParameter" time="0.847" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagsInOperations" time="0.395" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testParameter" time="0.773" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingRequestBody" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAvailabilityResource" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContact" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecuritySchemes" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthScope" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackOperationAnnotations" time="0.264" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingResponses" time="0.187" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationBookingResource" time="0.184" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentExampleAttribute" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAirlinesResource" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testVersion" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackAnnotations" time="0.196" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackOperationAnnotations" time="0.231" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInParameter" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationReviewResource" time="0.269" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInRequestBody" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRequestBodyAnnotations" time="0.236" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlows" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLinkParameter" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentExampleAttribute" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponses" time="0.322" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExternalDocumentation" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInComponents" time="0.117" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationUserResource" time="0.362" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExampleObject" time="0.131" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInAPIResponse" time="0.258" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExternalDocumentation" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExplode" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInEncoding" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testComponents" time="0.183" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponse" time="0.197" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExtensionParsing" time="0.130" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLicense" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInAPIResponse" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLink" time="0.173" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchemaProperty" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityRequirement" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchemaProperty" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackAnnotations" time="0.258" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInAPIResponse" time="0.244" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthScope" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagDeclarations" time="0.155" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationBookingResource" time="0.179" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagsInOperations" time="0.274" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponses" time="0.209" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInEncoding" time="0.116" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContact" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationReviewResource" time="0.233" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLinkParameter" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlow" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponse" time="0.178" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlows" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExceptionMappers" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testInfo" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlow" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInParameter" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRestClientNotPickedUp" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLicense" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExtensionParsing" time="0.137" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityRequirement" time="0.145" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInEncoding" time="0.133" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRequestBodyAnnotations" time="0.191" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAvailabilityResource" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchema" time="0.265" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInAPIResponse" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchema" time="0.239" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingResponses" time="0.212" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecuritySchemes" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityScheme" time="0.123" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLink" time="0.132" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testServer" time="0.463" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="2" name="FilterTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="28" time="9.156" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOpenAPI" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemAddOperation" time="0.148" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterLink" time="0.185" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOpenAPI" time="0.131" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterServer" time="0.455" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSecurityScheme" time="0.170" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterParameter" time="0.529" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterCallback" time="0.153" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOperation" time="0.152" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemEnsureOrder" time="0.139" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOperation" time="0.140" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterTag" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterTag" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterAPIResponse" time="3.520" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSchema" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterParameter" time="0.233" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterRequestBody" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemEnsureOrder" time="0.141" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterAPIResponse" time="0.670" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterServer" time="0.542" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterHeader" time="0.290" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemAddOperation" time="0.133" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterRequestBody" time="0.110" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterCallback" time="0.225" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterLink" time="0.151" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSchema" time="0.102" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterHeader" time="0.272" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSecurityScheme" time="0.079" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="3" name="ModelConstructionTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="30" time="2.353" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="requestBodyTest" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="exampleTest" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="apiResponsesTest" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="schemaTest" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="discriminatorTest" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="oAuthFlowTest" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="operationTest" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="encodingTest" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="callbackTest" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="pathItemTest" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="securityRequirementTest" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="contentTest" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="oAuthFlowsTest" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="tagTest" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="mediaTypeTest" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="licenseTest" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="serverVariableTest" time="0.044" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="pathsTest" time="0.058" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="securitySchemeTest" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="serverTest" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="componentsTest" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="infoTest" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="xmlTest" time="0.039" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="externalDocumentationTest" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="headerTest" time="0.050" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="openAPITest" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="linkTest" time="0.052" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="apiResponseTest" time="0.601" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="parameterTest" time="0.087" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="contactTest" time="0.067" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="4" name="ModelReaderAppTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="42" time="5.856" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testHeaderInComponents" time="0.108" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContentInAPIResponse" time="0.138" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityRequirement" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAirlinesResource" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testComponents" time="0.284" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContact" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecuritySchemes" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testComponents" time="0.276" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagsInOperations" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityRequirement" time="0.144" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagDeclarations" time="0.198" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSchema" time="0.124" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContentInAPIResponse" time="0.121" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testServer" time="0.230" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testServer" time="0.187" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAvailabilityGetParameter" time="0.705" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagDeclarations" time="0.166" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAvailabilityResource" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testLicense" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationBookingResource" time="0.117" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testInfo" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testHeaderInComponents" time="0.135" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAirlinesResource" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSchema" time="0.132" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExternalDocumentation" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testVersion" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExternalDocumentation" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExampleObject" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testVersion" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagsInOperations" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testInfo" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityScheme" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExampleObject" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAvailabilityGetParameter" time="0.702" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityScheme" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAPIResponse" time="0.127" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecuritySchemes" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAvailabilityResource" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAPIResponse" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testLicense" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationBookingResource" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContact" time="0.097" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="5" name="OASConfigExcludeClassTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.513" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassTest" name="testExcludedClass" time="0.228" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassTest" name="testExcludedClass" time="0.285" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="6" name="OASConfigExcludeClassesTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.344" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassesTest" name="testExcludedClasses" time="0.167" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassesTest" name="testExcludedClasses" time="0.177" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="7" name="OASConfigExcludePackageTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.269" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludePackageTest" name="testExcludePackage" time="0.146" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludePackageTest" name="testExcludePackage" time="0.123" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="8" name="OASConfigScanClassTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.392" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassTest" name="testScanClass" time="0.202" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassTest" name="testScanClass" time="0.190" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="9" name="OASConfigScanClassesTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.354" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassesTest" name="testScanClasses" time="0.193" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassesTest" name="testScanClasses" time="0.161" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="10" name="OASConfigScanDisableTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.267" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanDisableTest" name="testScanDisable" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanDisableTest" name="testScanDisable" time="0.187" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="11" name="OASConfigScanPackageTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.192" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanPackageTest" name="testScanPackage" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanPackageTest" name="testScanPackage" time="0.094" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="12" name="OASConfigSchemaTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.159" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigSchemaTest" name="testSchemaConfigApplied" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigSchemaTest" name="testSchemaConfigApplied" time="0.090" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="13" name="OASConfigServersTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.594" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigServersTest" name="testServer" time="0.314" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigServersTest" name="testServer" time="0.280" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="14" name="OASConfigWebInfTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.382" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigWebInfTest" name="testScanClass" time="0.224" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigWebInfTest" name="testScanClass" time="0.158" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="15" name="OASFactoryErrorTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="6" time="0.776" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="customAbstractClassTest" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="customClassTest" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="baseInterfaceTest" time="0.491" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="extendedBaseInterfaceTest" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="extendedInterfaceTest" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="nullValueTest" time="0.048" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="16" name="PetStoreAppTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="20" time="2.988" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlows" time="0.038" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testRequestBodySchema" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchemaDefaultResponseCode" time="0.214" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecuritySchemes" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSchema" time="0.200" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecuritySchemes" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSchema" time="0.157" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityScheme" time="0.199" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityScheme" time="0.269" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityRequirement" time="0.206" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlow" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlows" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testRequestBodySchema" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityRequirement" time="0.223" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testJsonResponseTypeWithQueryParameter" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchema" time="0.232" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlow" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchemaDefaultResponseCode" time="0.244" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchema" time="0.301" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testDefaultResponseType" time="0.060" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs1618qmwnr16-n.fyre.ibm.com" id="17" name="StaticDocumentTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="2.921" timestamp="03 Jul 2021 05:25:50 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.StaticDocumentTest" name="testStaticDocument" time="1.669" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.StaticDocumentTest" name="testStaticDocument" time="1.252" />
+  </testsuite>
+</testsuites>
+----
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="1" name="AirlinesAppTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="94" time="18.531" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLicense" time="0.059" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExceptionMappers" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlow" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInComponents" time="0.128" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testServer" time="0.496" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationUserResource" time="0.427" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponses" time="0.450" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponse" time="0.278" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlows" time="0.088" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInAPIResponse" time="0.447" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInAPIResponse" time="0.311" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationBookingResource" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagDeclarations" time="0.155" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationReviewResource" time="0.313" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAirlinesResource" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExplode" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingResponses" time="0.191" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testInfo" time="0.128" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInAPIResponse" time="0.560" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityScheme" time="0.160" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testServer" time="0.549" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagsInOperations" time="0.294" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testStaticFileDefinitions" time="0.398" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExampleObject" time="0.140" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInEncoding" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRequestBodyAnnotations" time="0.232" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContact" time="0.140" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthScope" time="0.066" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAirlinesResource" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLicense" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityRequirement" time="0.221" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecuritySchemes" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAvailabilityResource" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInRequestBody" time="0.114" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackOperationAnnotations" time="0.305" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExternalDocumentation" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInEncoding" time="0.100" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLink" time="0.201" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testParameter" time="0.869" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchemaProperty" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInAPIResponse" time="0.282" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationAvailabilityResource" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testComponents" time="0.405" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthScope" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLink" time="0.165" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExternalDocumentation" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchema" time="0.274" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInComponents" time="0.144" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackAnnotations" time="0.246" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityScheme" time="0.171" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationUserResource" time="0.333" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingRequestBody" time="0.107" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlows" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecuritySchemes" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInAPIResponse" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOAuthFlow" time="0.133" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchemaProperty" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRestClientNotPickedUp" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testVersion" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExampleObject" time="0.137" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationBookingResource" time="0.170" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInEncoding" time="0.145" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRequestBodyAnnotations" time="0.221" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testStaticFileDefinitions" time="0.358" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExplode" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRefHeaderInAPIResponse" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInParameter" time="0.116" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentExampleAttribute" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSchema" time="0.268" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackOperationAnnotations" time="0.381" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLinkParameter" time="0.130" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentExampleAttribute" time="0.113" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponses" time="0.241" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingResponses" time="0.236" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testEncodingRequestBody" time="0.123" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testHeaderInEncoding" time="0.146" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testCallbackAnnotations" time="0.199" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExceptionMappers" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testAPIResponse" time="0.240" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testVersion" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagsInOperations" time="0.275" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInRequestBody" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testSecurityRequirement" time="0.162" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testInfo" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContentInParameter" time="0.153" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testComponents" time="0.408" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testRestClientNotPickedUp" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testOperationReviewResource" time="0.219" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testParameter" time="0.960" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testTagDeclarations" time="0.182" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testLinkParameter" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExtensionParsing" time="0.148" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testExtensionParsing" time="0.148" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.AirlinesAppTest" name="testContact" time="0.079" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="2" name="FilterTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="28" time="10.794" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterCallback" time="0.145" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemEnsureOrder" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemAddOperation" time="0.133" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterAPIResponse" time="4.188" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterParameter" time="0.289" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterRequestBody" time="0.124" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemAddOperation" time="0.191" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterTag" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSchema" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOperation" time="0.177" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterHeader" time="0.347" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOpenAPI" time="0.153" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOperation" time="0.172" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterPathItemEnsureOrder" time="0.154" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterParameter" time="0.402" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterCallback" time="0.292" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterLink" time="0.208" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterTag" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterAPIResponse" time="0.828" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterOpenAPI" time="0.177" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterRequestBody" time="0.123" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterLink" time="0.192" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterHeader" time="0.379" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSecurityScheme" time="0.134" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterServer" time="0.546" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSecurityScheme" time="0.230" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterSchema" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.FilterTest" name="testFilterServer" time="0.657" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="3" name="ModelConstructionTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="30" time="2.921" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="mediaTypeTest" time="0.072" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="serverVariableTest" time="0.073" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="externalDocumentationTest" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="oAuthFlowTest" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="securitySchemeTest" time="0.071" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="securityRequirementTest" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="serverTest" time="0.046" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="linkTest" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="componentsTest" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="pathItemTest" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="openAPITest" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="callbackTest" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="pathsTest" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="exampleTest" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="discriminatorTest" time="0.105" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="encodingTest" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="headerTest" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="requestBodyTest" time="0.057" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="contactTest" time="0.099" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="operationTest" time="0.060" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="parameterTest" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="tagTest" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="xmlTest" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="infoTest" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="contentTest" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="apiResponseTest" time="0.621" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="apiResponsesTest" time="0.157" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="licenseTest" time="0.090" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="schemaTest" time="0.079" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelConstructionTest" name="oAuthFlowsTest" time="0.078" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="4" name="ModelReaderAppTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="42" time="7.042" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testComponents" time="0.311" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSchema" time="0.161" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testInfo" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecuritySchemes" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExampleObject" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testLicense" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContentInAPIResponse" time="0.119" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContentInAPIResponse" time="0.162" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagsInOperations" time="0.112" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityRequirement" time="0.175" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAvailabilityResource" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationBookingResource" time="0.162" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testServer" time="0.273" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testVersion" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAvailabilityGetParameter" time="0.817" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSchema" time="0.144" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityRequirement" time="0.128" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecuritySchemes" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testInfo" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagDeclarations" time="0.216" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContact" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagsInOperations" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExampleObject" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityScheme" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExternalDocumentation" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationBookingResource" time="0.130" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAPIResponse" time="0.144" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testHeaderInComponents" time="0.145" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAvailabilityGetParameter" time="0.691" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testExternalDocumentation" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testComponents" time="0.379" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testHeaderInComponents" time="0.120" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testContact" time="0.092" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testServer" time="0.296" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testSecurityScheme" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testAPIResponse" time="0.147" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testLicense" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAirlinesResource" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAvailabilityResource" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testVersion" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testOperationAirlinesResource" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest" name="testTagDeclarations" time="0.270" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="5" name="OASConfigExcludeClassTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.512" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassTest" name="testExcludedClass" time="0.288" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassTest" name="testExcludedClass" time="0.224" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="6" name="OASConfigExcludeClassesTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.509" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassesTest" name="testExcludedClasses" time="0.247" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludeClassesTest" name="testExcludedClasses" time="0.262" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="7" name="OASConfigExcludePackageTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.205" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludePackageTest" name="testExcludePackage" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigExcludePackageTest" name="testExcludePackage" time="0.107" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="8" name="OASConfigScanClassTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.636" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassTest" name="testScanClass" time="0.309" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassTest" name="testScanClass" time="0.327" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="9" name="OASConfigScanClassesTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.683" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassesTest" name="testScanClasses" time="0.367" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanClassesTest" name="testScanClasses" time="0.316" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="10" name="OASConfigScanDisableTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.464" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanDisableTest" name="testScanDisable" time="0.259" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanDisableTest" name="testScanDisable" time="0.205" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="11" name="OASConfigScanPackageTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.242" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanPackageTest" name="testScanPackage" time="0.120" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigScanPackageTest" name="testScanPackage" time="0.122" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="12" name="OASConfigSchemaTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.218" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigSchemaTest" name="testSchemaConfigApplied" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigSchemaTest" name="testSchemaConfigApplied" time="0.120" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="13" name="OASConfigServersTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.678" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigServersTest" name="testServer" time="0.373" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigServersTest" name="testServer" time="0.305" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="14" name="OASConfigWebInfTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="0.369" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigWebInfTest" name="testScanClass" time="0.194" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASConfigWebInfTest" name="testScanClass" time="0.175" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="15" name="OASFactoryErrorTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="6" time="0.778" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="customClassTest" time="0.095" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="extendedInterfaceTest" time="0.041" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="nullValueTest" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="customAbstractClassTest" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="baseInterfaceTest" time="0.464" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.OASFactoryErrorTest" name="extendedBaseInterfaceTest" time="0.050" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="16" name="PetStoreAppTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="20" time="3.848" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testDefaultResponseType" time="0.085" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlows" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSchema" time="0.347" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchema" time="0.404" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testJsonResponseTypeWithQueryParameter" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchema" time="0.216" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlows" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecuritySchemes" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchemaDefaultResponseCode" time="0.239" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityRequirement" time="0.281" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlow" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testRequestBodySchema" time="0.132" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testAPIResponseSchemaDefaultResponseCode" time="0.248" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityScheme" time="0.294" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testOAuthFlow" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityScheme" time="0.278" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSchema" time="0.334" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testRequestBodySchema" time="0.177" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecurityRequirement" time="0.266" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.PetStoreAppTest" name="testSecuritySchemes" time="0.124" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh1696qmyt4ic-n.fyre.ibm.com" id="17" name="StaticDocumentTest" package="org.eclipse.microprofile.openapi.tck" skipped="0" tests="2" time="3.347" timestamp="03 Jul 2021 05:44:02 GMT">
+      <testcase classname="org.eclipse.microprofile.openapi.tck.StaticDocumentTest" name="testStaticDocument" time="1.739" />
+      <testcase classname="org.eclipse.microprofile.openapi.tck.StaticDocumentTest" name="testStaticDocument" time="1.608" />
+  </testsuite>
+</testsuites>
+----

--- a/microprofile/4.1/opentracing/2.0/TCKResults.adoc
+++ b/microprofile/4.1/opentracing/2.0/TCKResults.adoc
@@ -1,0 +1,203 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile OpenTracing 2.0.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile OpenTracing 2.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-opentracing-2.0/microprofile-opentracing-spec-2.0.html[MicroProfile OpenTracing 2.0]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+RHEL 8
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="ebcprs0899qmwpw6c-n.fyre.ibm.com" id="1" name="ClientRegistrarTests" package="org.eclipse.microprofile.opentracing.tck" tests="4" time="0.541" timestamp="3 Jul 2021 06:23:37 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrarAsync" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrarExecutorAsync" time="0.139" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrarExecutor" time="0.109" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrar" time="0.204" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs0899qmwpw6c-n.fyre.ibm.com" id="2" name="OpenTracingClassMethodNameClientTests" package="org.eclipse.microprofile.opentracing.tck" tests="15" time="12.412" timestamp="3 Jul 2021 06:23:37 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testAsyncLocalSpan" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testLocalSpanHasParent" time="0.065" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testNestedSpansWithClientFailure" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testMultithreadedNestedSpansAsync" time="5.736" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testStandardTags" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testException" time="0.083" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testAnnotations" time="0.078" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testError" time="0.096" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testOperationName" time="0.081" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testNotTraced" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testClassOperationName" time="0.089" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testClassAndMethodOperationName" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testNestedSpans" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testAnnotationException" time="0.141" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testMultithreadedNestedSpans" time="5.491" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs0899qmwpw6c-n.fyre.ibm.com" id="3" name="OpenTracingDefaultClientTests" package="org.eclipse.microprofile.opentracing.tck" tests="15" time="18.980" timestamp="3 Jul 2021 06:23:37 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testMultithreadedNestedSpans" time="8.105" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testNestedSpansWithClientFailure" time="0.189" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testNestedSpans" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testMultithreadedNestedSpansAsync" time="6.426" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testClassAndMethodOperationName" time="0.124" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testOperationName" time="2.074" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testException" time="0.169" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testError" time="0.111" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testClassOperationName" time="0.150" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testNotTraced" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testAnnotationException" time="0.952" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testAnnotations" time="0.160" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testAsyncLocalSpan" time="0.169" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testLocalSpanHasParent" time="0.082" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testStandardTags" time="0.082" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs0899qmwpw6c-n.fyre.ibm.com" id="4" name="OpenTracingHTTPPathNameTests" package="org.eclipse.microprofile.opentracing.tck" tests="17" time="9.735" timestamp="3 Jul 2021 06:23:37 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testException" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testMultithreadedNestedSpansAsync" time="4.131" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testNestedSpans" time="0.098" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testError" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testStandardTags" time="0.080" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testOperationName" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testWildcard" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testAnnotationException" time="0.142" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testClassAndMethodOperationName" time="0.054" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testClassOperationName" time="0.055" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testNestedSpansWithClientFailure" time="0.106" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testAsyncLocalSpan" time="0.051" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testTwoSameParams" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testMultithreadedNestedSpans" time="4.456" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testLocalSpanHasParent" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testNotTraced" time="0.119" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testAnnotations" time="0.059" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs0899qmwpw6c-n.fyre.ibm.com" id="5" name="OpenTracingSkipPatternTests" package="org.eclipse.microprofile.opentracing.tck" tests="10" time="1.141" timestamp="3 Jul 2021 06:23:37 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsApplicationNotTraced" time="0.070" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsBaseNotTraced" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testSkipFooBar" time="0.068" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testHealthNotTraced" time="0.243" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsVendorNotTraced" time="0.062" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testOpenAPINotTraced" time="0.138" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testSkipFoo" time="0.074" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsNotTraced" time="0.061" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testSkipSimple" time="0.271" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testExplicitlyTraced" time="0.105" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs0899qmwpw6c-n.fyre.ibm.com" id="6" name="OpenTracingMpRestClientTests" package="org.eclipse.microprofile.opentracing.tck.rest.client" tests="5" time="19.024" timestamp="3 Jul 2021 06:24:24 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testClientNotTraced" time="1.074" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testMultithreadedNestedSpansAsync" time="6.661" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testMethodNotTraced" time="0.198" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testMultithreadedNestedSpans" time="9.058" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testNestedSpans" time="2.033" />
+  </testsuite>
+</testsuites>
+
+----
+
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="ebcprh0991qmyvwkm-n.fyre.ibm.com" id="1" name="ClientRegistrarTests" package="org.eclipse.microprofile.opentracing.tck" tests="4" time="0.510" timestamp="3 Jul 2021 06:24:04 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrarExecutorAsync" time="0.149" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrar" time="0.160" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrarAsync" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.ClientRegistrarTests" name="testClientRegistrarExecutor" time="0.108" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0991qmyvwkm-n.fyre.ibm.com" id="2" name="OpenTracingClassMethodNameClientTests" package="org.eclipse.microprofile.opentracing.tck" tests="15" time="12.559" timestamp="3 Jul 2021 06:24:04 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testMultithreadedNestedSpansAsync" time="5.205" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testNestedSpansWithClientFailure" time="0.075" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testError" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testNotTraced" time="0.042" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testMultithreadedNestedSpans" time="6.040" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testAnnotationException" time="0.217" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testAsyncLocalSpan" time="0.091" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testException" time="0.086" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testStandardTags" time="0.084" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testOperationName" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testClassAndMethodOperationName" time="0.097" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testNestedSpans" time="0.094" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testAnnotations" time="0.163" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testClassOperationName" time="0.093" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingClassMethodNameClientTests" name="testLocalSpanHasParent" time="0.125" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0991qmyvwkm-n.fyre.ibm.com" id="3" name="OpenTracingDefaultClientTests" package="org.eclipse.microprofile.opentracing.tck" tests="15" time="20.040" timestamp="3 Jul 2021 06:24:04 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testError" time="0.125" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testClassAndMethodOperationName" time="0.146" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testStandardTags" time="0.067" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testMultithreadedNestedSpansAsync" time="6.726" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testClassOperationName" time="0.104" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testException" time="0.226" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testOperationName" time="0.076" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testMultithreadedNestedSpans" time="8.724" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testNotTraced" time="0.115" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testLocalSpanHasParent" time="2.175" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testNestedSpansWithClientFailure" time="0.183" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testAnnotations" time="0.191" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testAsyncLocalSpan" time="0.103" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testAnnotationException" time="0.926" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingDefaultClientTests" name="testNestedSpans" time="0.153" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0991qmyvwkm-n.fyre.ibm.com" id="4" name="OpenTracingHTTPPathNameTests" package="org.eclipse.microprofile.opentracing.tck" tests="17" time="10.427" timestamp="3 Jul 2021 06:24:04 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testTwoSameParams" time="0.069" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testWildcard" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testNotTraced" time="0.040" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testError" time="0.047" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testLocalSpanHasParent" time="0.064" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testMultithreadedNestedSpansAsync" time="3.871" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testStandardTags" time="0.048" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testClassOperationName" time="0.101" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testAnnotations" time="0.126" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testOperationName" time="0.056" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testAnnotationException" time="0.137" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testException" time="0.077" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testMultithreadedNestedSpans" time="5.181" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testNestedSpans" time="0.136" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testClassAndMethodOperationName" time="0.118" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testNestedSpansWithClientFailure" time="0.213" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingHTTPPathNameTests" name="testAsyncLocalSpan" time="0.079" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0991qmyvwkm-n.fyre.ibm.com" id="5" name="OpenTracingSkipPatternTests" package="org.eclipse.microprofile.opentracing.tck" tests="10" time="0.970" timestamp="3 Jul 2021 06:24:04 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testSkipSimple" time="0.125" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testOpenAPINotTraced" time="0.126" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsBaseNotTraced" time="0.043" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testHealthNotTraced" time="0.221" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsVendorNotTraced" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsApplicationNotTraced" time="0.049" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testSkipFooBar" time="0.063" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testMetricsNotTraced" time="0.045" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testSkipFoo" time="0.053" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.OpenTracingSkipPatternTests" name="testExplicitlyTraced" time="0.182" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprh0991qmyvwkm-n.fyre.ibm.com" id="6" name="OpenTracingMpRestClientTests" package="org.eclipse.microprofile.opentracing.tck.rest.client" tests="5" time="19.529" timestamp="3 Jul 2021 06:24:52 GMT">
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testMultithreadedNestedSpansAsync" time="9.082" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testClientNotTraced" time="0.917" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testNestedSpans" time="0.176" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testMultithreadedNestedSpans" time="9.029" />
+      <testcase classname="org.eclipse.microprofile.opentracing.tck.rest.client.OpenTracingMpRestClientTests" name="testMethodNotTraced" time="0.325" />
+  </testsuite>
+</testsuites>
+
+----

--- a/microprofile/4.1/restclient/2.0/TCKResults.adoc
+++ b/microprofile/4.1/restclient/2.0/TCKResults.adoc
@@ -23,8 +23,8 @@ Java 8 and 11
 
 * Summary of the information for the certification environment, operating system, cloud, ...:
 +
-MacOS 11.4 for Java 8
-RHEL 8 for Java 11
+** MacOS 11.4 for Java 8
+** RHEL 8 for Java 11
 
 Java 8 Test results:
 

--- a/microprofile/4.1/restclient/2.0/TCKResults.adoc
+++ b/microprofile/4.1/restclient/2.0/TCKResults.adoc
@@ -1,0 +1,1002 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile Rest Client2.0.
+
+== Open Liberty 21.0.0.8-beta - MicroProfile Rest Client 2.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/21.0.0.8-beta/openliberty-runtime-21.0.0.8-beta.zip[Open Liberty 21.0.0.8-beta]
+
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-rest-client-2.0/microprofile-rest-client-spec-2.0.html[MicroProfile Rest Client 2.0]
+
+* Public URL of TCK Results Summary:
++
+link:TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8 and 11
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+MacOS 11.4 for Java 8
+RHEL 8 for Java 11
+
+Java 8 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="0" name="AdditionalRegistrationTest" package="org.eclipse.microprofile.rest.client.tck" tests="8" time="0.559" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderInstanceWithPriorities" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterInstanceWithPriority" time="0.033" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterProvidersWithPriority" time="0.025" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterInstance" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderInstance" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderClass" time="0.351" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderClassWithPriorities" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="testPropertiesRegistered" time="0.027" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="1" name="BeanParamTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.262" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.BeanParamTest" name="sendsParamsSpecifiedInBeanParam" time="0.262" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="2" name="CallMultipleMappersTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="1.032" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CallMultipleMappersTest" name="testCallsTwoProvidersWithTwoRegisteredProvider" time="1.032" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="3" name="ClientHeaderParamTest" package="org.eclipse.microprofile.rest.client.tck" tests="14" time="1.679" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesExplicitClientHeaderParamOnInterface" time="0.061" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testComputedClientHeaderParamOnInterface" time="0.872" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesExplicitClientHeaderParamOnMethod" time="0.057" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExplicitClientHeaderParamOnMethodOverridesClientHeaderParamOnInterface" time="0.062" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExplicitClientHeaderParamOnInterface" time="0.067" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExceptionInRequiredComputeMethodThrowsClientErrorException" time="0.046" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExplicitClientHeaderParamOnMethod" time="0.068" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesComputedClientHeaderParamOnMethod" time="0.070" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testComputedClientHeaderParamOnMethod" time="0.076" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderNotSentWhenExceptionThrownAndRequiredIsFalse" time="0.047" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesComputedClientHeaderParamOnInterface" time="0.063" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testComputedClientHeaderParamOnMethodOverridesClientHeaderParamOnInterface" time="0.065" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testMultivaluedHeaderSentWhenInvokingComputeMethodFromSeparateClass" time="0.063" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testMultivaluedHeaderInterfaceExplicit" time="0.062" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="4" name="ClientHeadersFactoryTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.348" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeadersFactoryTest" name="testClientHeadersFactoryInvoked" time="0.348" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="5" name="ClientReuseTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="1.498" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientReuseTest" name="shouldReuseClientAfterFailure" time="1.498" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="6" name="CloseTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="0.373" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterAutoCloseableClose" time="0.270" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterCloseOnInterfaceThatExtendsAutoCloseable" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterCloseOnInterfaceThatExtendsCloseable" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterCloseableClose" time="0.032" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="7" name="CustomHttpMethodTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.236" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CustomHttpMethodTest" name="invokesUserDefinedHttpMethod" time="0.236" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="8" name="DefaultExceptionMapperConfigTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="1.141" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperConfigTest" name="testNoExceptionThrownWhenDisabledDuringBuild" time="1.141" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="9" name="DefaultExceptionMapperTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="1.107" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testNoExceptionThrownWhenDisabledDuringBuild" time="0.053" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testLowerPriorityMapperTakesPrecedenceFromDefault" time="0.064" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testExceptionThrownWhenPropertySetToFalse" time="0.935" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testPropagationOfResponseDetailsFromDefaultMapper" time="0.055" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="10" name="DefaultMIMETypeTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="0.347" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultMIMETypeTest" name="testDefaultMIMETypeIsApplicationJson_ContentType" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultMIMETypeTest" name="testDefaultMIMETypeIsApplicationJson_Accept" time="0.321" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="11" name="ExceptionMapperTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.705" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ExceptionMapperTest" name="testWithOneRegisteredProvider" time="1.640" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ExceptionMapperTest" name="testWithTwoRegisteredProviders" time="0.065" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="12" name="FATSuite" package="org.eclipse.microprofile.rest.client.tck" skipped="0" tests="1" time="545.366" timestamp="2021-07-07T14:26:30">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.RestClientTckPackageTest" name="testRestClientTck" time="540.633" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="13" name="FeatureRegistrationTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.548" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FeatureRegistrationTest" name="testFeatureRegistrationViaCDI" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FeatureRegistrationTest" name="testFeatureRegistrationViaBuilder" time="1.514" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="14" name="FollowRedirectsTest" package="org.eclipse.microprofile.rest.client.tck" tests="8" time="2.764" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test302Follows" time="0.090" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test301Default" time="2.161" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test302Default" time="0.093" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test303Follows" time="0.076" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test307Follows" time="0.081" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test303Default" time="0.083" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test307Default" time="0.067" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test301Follows" time="0.113" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="15" name="InheritanceTest" package="org.eclipse.microprofile.rest.client.tck" tests="3" time="0.304" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InheritanceTest" name="canInvokeOverriddenMethodOnChildInterface" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InheritanceTest" name="canInvokeMethodOnBaseInterface" time="0.252" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InheritanceTest" name="canInvokeMethodOnChildInterface" time="0.026" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="16" name="InvalidInterfaceTest" package="org.eclipse.microprofile.rest.client.tck" tests="11" time="0.652" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleClientHeaderParamsSpecifySameHeaderOnInterface" time="0.056" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtTypeLevel" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenClientHeaderParamComputeValueSpecifiesMethodWithInvalidSignature" time="0.344" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleHeaderValuesSpecifiedIncludeComputeMethodOnInterface" time="0.028" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithPathParamAnnotationButNoURITemplate" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtMethodLevel" time="0.025" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenClientHeaderParamComputeValueSpecifiesMissingMethod" time="0.038" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMultipleHTTPMethodAnnotations" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleHeaderValuesSpecifiedIncludeComputeMethodOnMethod" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMismatchedPathParameter" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleClientHeaderParamsSpecifySameHeaderOnMethod" time="0.025" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="17" name="InvokeSimpleGetOperationTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="2.074" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeSimpleGetOperationTest" name="testGetExecutionWithBuiltClient" time="2.074" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="18" name="InvokeWithBuiltProvidersTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="0.845" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithBuiltProvidersTest" name="testInvokesPostOperationWithRegisteredProviders" time="0.783" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithBuiltProvidersTest" name="testInvokesPutOperationWithRegisteredProviders" time="0.062" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="19" name="InvokeWithJsonPProviderTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="2.929" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testGetSingleExecutesForBothClients" time="0.118" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testPostExecutes" time="0.202" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testPutExecutes" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testGetExecutesForBothClients" time="2.482" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="20" name="InvokeWithRegisteredProvidersTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.209" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithRegisteredProvidersTest" name="testInvokesPutOperationWithAnnotatedProviders" time="0.076" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithRegisteredProvidersTest" name="testInvokesPostOperationWithAnnotatedProviders" time="1.133" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="21" name="InvokedMethodTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.337" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokedMethodTest" name="testRequestFilterReturnsMethodInvoked" time="0.337" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="22" name="MultiRegisteredTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="2.293" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.MultiRegisteredTest" name="testOverrideInterfaceAndProviderAnnotationOnBuilder" time="2.225" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.MultiRegisteredTest" name="testOverrideProviderAnnotationOnBuilder" time="0.068" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="23" name="ProducesConsumesTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.323" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProducesConsumesTest" name="testProducesConsumesAnnotationOnInterface" time="1.290" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProducesConsumesTest" name="testProducesConsumesAnnotationOnMethod" time="0.033" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="24" name="ProvidesRestClientBuilderTest" package="org.eclipse.microprofile.rest.client.tck" tests="3" time="0.759" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProvidesRestClientBuilderTest" name="testCanCallStaticLoader" time="0.368" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProvidesRestClientBuilderTest" name="testLastBaseUriOrBaseUrlCallWins" time="0.351" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProvidesRestClientBuilderTest" name="testIllegalStateExceptionThrownWhenNoBaseUriOrUrlSpecified" time="0.040" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="25" name="ProxyServerTest" package="org.eclipse.microprofile.rest.client.tck" tests="5" time="1.219" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testProxy" time="0.576" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testNullHostName" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testInvalidPortNumber" time="0.546" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testInvalidPortNumber2" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testInvalidPortNumber1" time="0.035" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="26" name="QueryParamStyleTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="0.436" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="defaultStyleIsMultiPair" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="explicitMultiPair" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="commaSeparated" time="0.034" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="arrayPairs" time="0.345" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="27" name="RestClientBuilderListenerTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.311" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.RestClientBuilderListenerTest" name="testRegistrarInvoked" time="0.311" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="28" name="RestClientListenerTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.337" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.RestClientListenerTest" name="testRestClientListenerInvoked" time="0.337" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="29" name="SubResourceTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.339" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.SubResourceTest" name="canInvokeMethodOnSubResourceInterface" time="0.339" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="30" name="AsyncMethodTest" package="org.eclipse.microprofile.rest.client.tck.asynctests" tests="4" time="1.349" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testNullExecutorServiceThrowsIllegalArgumentException" time="0.040" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testAsyncInvocationInterceptorProvider" time="1.172" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testInterfaceMethodWithCompletionStageObjectReturnIsInvokedAsynchronously" time="0.063" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testExecutorService" time="0.074" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="31" name="CDIInvokeAsyncSimpleGetOperationTest" package="org.eclipse.microprofile.rest.client.tck.asynctests" tests="2" time="0.934" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.CDIInvokeAsyncSimpleGetOperationTest" name="testInvokesGetOperationWithCDIBean" time="0.491" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.CDIInvokeAsyncSimpleGetOperationTest" name="testHasDependentScopedByDefault" time="0.443" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="32" name="CDIClientHeadersFactoryTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="1" time="0.256" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIClientHeadersFactoryTest" name="testClientHeadersFactoryInvoked" time="0.256" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="33" name="CDIFollowRedirectsTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="8" time="1.867" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test301Default" time="1.208" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test302Default" time="0.091" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test302Follows" time="0.100" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test303Default" time="0.087" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test301Follows" time="0.097" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test307Default" time="0.089" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test307Follows" time="0.091" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test303Follows" time="0.104" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="34" name="CDIInterceptorTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="2" time="0.309" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInterceptorTest" name="testInterceptorInvoked" time="0.277" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInterceptorTest" name="testInterceptorNotInvokedWhenNoAnnotationApplied" time="0.032" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="35" name="CDIInvokeSimpleGetOperationTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="2" time="0.816" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeSimpleGetOperationTest" name="testInvokesGetOperationWithCDIBean" time="0.368" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeSimpleGetOperationTest" name="testHasDependentScopedByDefault" time="0.448" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="36" name="CDIInvokeWithRegisteredProvidersTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="6" time="1.432" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPostOperation_viaMPConfig" time="0.132" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPostOperation_viaMPConfigWithConfigKey" time="0.118" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPutOperation_viaAnnotation" time="0.105" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPostOperation_viaAnnotation" time="0.940" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPutOperation_viaMPConfigWithConfigKey" time="0.065" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPutOperation_viaMPConfig" time="0.072" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="37" name="CDIManagedProviderTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="4" time="0.400" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testCDIProviderSpecifiedInMPConfig" time="0.307" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testInstanceProviderSpecifiedViaRestClientBuilderDoesNotUseCDIManagedProvider" time="0.033" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testCDIProviderSpecifiedViaRestClientBuilder" time="0.032" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testCDIProviderSpecifiedViaAnnotation" time="0.028" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="38" name="CDIProxyServerTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="1" time="1.318" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIProxyServerTest" name="testProxy" time="1.318" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="39" name="CDIQueryParamStyleTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="4" time="0.495" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="defaultStyleIsMultiPair" time="0.042" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="explicitMultiPair" time="0.050" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="commaSeparated" time="0.041" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="arrayPairs" time="0.362" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="40" name="CDIURIvsURLConfigTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="1.058" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIURIvsURLConfigTest" name="testBaseUriInRegisterRestClientAnnotation" time="0.553" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIURIvsURLConfigTest" name="testURItakesPrecedenceOverURL" time="0.470" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIURIvsURLConfigTest" name="testMPConfigURIOverridesBaseUriInRegisterRestClientAnnotation" time="0.035" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="41" name="ConfigKeyForMultipleInterfacesTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="1" time="0.283" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.ConfigKeyForMultipleInterfacesTest" name="testConfigKeyUsedForUri" time="0.283" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="42" name="ConfigKeyTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="2" time="1.727" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.ConfigKeyTest" name="testConfigKeyUsedForUri" time="1.692" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.ConfigKeyTest" name="testFullyQualifiedClassnamePropTakesPrecedenceOverConfigKey" time="0.035" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="43" name="HasAppScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.385" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasAppScopeTest" name="testHasApplicationScopedWhenAnnotated" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasAppScopeTest" name="testHasApplicationScoped" time="0.336" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasAppScopeTest" name="testHasApplicationScopedFromConfigKey" time="0.023" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="44" name="HasConversationScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.314" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasConversationScopeTest" name="testHasConversationScoped" time="0.265" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasConversationScopeTest" name="testHasConversationScopedWhenAnnotated" time="0.024" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasConversationScopeTest" name="testHasConversationScopedFromConfigKey" time="0.025" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="45" name="HasRequestScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.297" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasRequestScopeTest" name="testHasRequestScoped" time="0.253" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasRequestScopeTest" name="testHasRequestScopedWhenAnnotated" time="0.022" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasRequestScopeTest" name="testHasRequestScopedFromConfigKey" time="0.022" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="46" name="HasSessionScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.273" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSessionScopeTest" name="testHasSingletonScoped" time="0.020" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSessionScopeTest" name="testHasSessionScopedWhenAnnotated" time="0.023" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSessionScopeTest" name="testHasSessionScopedFromConfigKey" time="0.230" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="47" name="HasSingletonScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="1.061" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSingletonScopeTest" name="testHasSingletonScoped" time="0.972" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSingletonScopeTest" name="testHasSingletonScopedWhenAnnotated" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSingletonScopeTest" name="testHasSingletonScopedFromConfigKey" time="0.050" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="48" name="InvokeWithJsonBProviderTest" package="org.eclipse.microprofile.rest.client.tck.jsonb" tests="2" time="1.270" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.jsonb.InvokeWithJsonBProviderTest" name="testCanSeePrivatePropertiesViaContextResolver" time="1.151" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.jsonb.InvokeWithJsonBProviderTest" name="testGetExecutesForBothClients" time="0.119" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="49" name="SslContextTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="2" time="1.037" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest" name="shouldFailedMutualSslWithoutSslContext" time="0.311" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest" name="shouldSucceedMutualSslWithValidSslContext" time="0.726" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="50" name="SslHostnameVerifierTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="7" time="1.588" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldPassSslSessionAndHostnameToHostnameVerifier" time="0.196" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldSucceedWithAcceptingHostnameVerifierCDI" time="0.153" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldPassSslSessionAndHostnameToHostnameVerifierCDI" time="0.106" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldSucceedWithAcceptingHostnameVerifier" time="0.188" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldFailWithRejectingHostnameVerifier" time="0.618" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldFailWithoutHostnameAndNoVerifier" time="0.191" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldFailWithRejectingHostnameVerifierCDI" time="0.136" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="51" name="SslMutualTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="7" time="5.305" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldWorkWithClientSignatureFromClasspathCDI" time="0.711" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithInvalidClientSignature" time="1.053" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldWorkWithClientSignatureCDI" time="0.696" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithNoClientSignatureCDI" time="0.719" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithNoClientSignature" time="0.684" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithInvalidClientSignatureCDI" time="0.560" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldWorkWithClientSignature" time="0.882" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="52" name="SslTrustStoreTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="7" time="3.858" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithNonMatchingKeystoreCDI" time="0.261" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldSucceedWithRegisteredSelfSignedKeystore" time="0.327" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithNonMatchingKeystore" time="0.657" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithSelfSignedKeystoreCDI" time="1.829" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithSelfSignedKeystore" time="0.278" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldSucceedWithRegisteredSelfSignedKeystoreCDI" time="0.253" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldSucceedWithRegisteredSelfSignedKeystoreFromResourceCDI" time="0.253" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="53" name="TimeoutBuilderIndependentOfMPConfigTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="13.245" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest" name="testConnectTimeout" time="7.833" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest" name="testReadTimeout" time="5.412" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="54" name="TimeoutTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="12.935" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest" name="testReadTimeout" time="5.373" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest" name="testConnectTimeout" time="7.562" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="55" name="TimeoutViaMPConfigTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="16.952" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest" name="testReadTimeout" time="8.354" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest" name="testConnectTimeout" time="8.598" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="Andys-MBP" id="56" name="TimeoutViaMPConfigWithConfigKeyTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="16.769" timestamp="7 Jul 2021 14:35:31 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest" name="testReadTimeout" time="8.310" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest" name="testConnectTimeout" time="8.459" />
+
+  </testsuite>
+</testsuites>
+
+----
+
+
+Java 11 Test results:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="0" name="AdditionalRegistrationTest" package="org.eclipse.microprofile.rest.client.tck" tests="8" time="0.865" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderInstance" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderClassWithPriorities" time="0.046" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="testPropertiesRegistered" time="0.068" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterInstance" time="0.048" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderInstanceWithPriorities" time="0.068" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterAMultiTypedProviderClass" time="0.432" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterProvidersWithPriority" time="0.118" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.AdditionalRegistrationTest" name="shouldRegisterInstanceWithPriority" time="0.046" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="1" name="BeanParamTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.724" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.BeanParamTest" name="sendsParamsSpecifiedInBeanParam" time="0.724" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="2" name="CallMultipleMappersTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="1.387" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CallMultipleMappersTest" name="testCallsTwoProvidersWithTwoRegisteredProvider" time="1.387" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="3" name="ClientHeaderParamTest" package="org.eclipse.microprofile.rest.client.tck" tests="14" time="3.267" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExplicitClientHeaderParamOnMethodOverridesClientHeaderParamOnInterface" time="0.167" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testComputedClientHeaderParamOnMethod" time="0.146" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testMultivaluedHeaderInterfaceExplicit" time="0.177" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderNotSentWhenExceptionThrownAndRequiredIsFalse" time="0.121" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesExplicitClientHeaderParamOnInterface" time="0.203" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testComputedClientHeaderParamOnMethodOverridesClientHeaderParamOnInterface" time="0.158" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesComputedClientHeaderParamOnMethod" time="0.192" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExplicitClientHeaderParamOnInterface" time="0.118" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExceptionInRequiredComputeMethodThrowsClientErrorException" time="0.087" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testMultivaluedHeaderSentWhenInvokingComputeMethodFromSeparateClass" time="0.116" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testExplicitClientHeaderParamOnMethod" time="0.152" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesExplicitClientHeaderParamOnMethod" time="0.151" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testHeaderParamOverridesComputedClientHeaderParamOnInterface" time="0.109" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest" name="testComputedClientHeaderParamOnInterface" time="1.370" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="4" name="ClientHeadersFactoryTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.597" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientHeadersFactoryTest" name="testClientHeadersFactoryInvoked" time="0.597" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="5" name="ClientReuseTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="1.171" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ClientReuseTest" name="shouldReuseClientAfterFailure" time="1.171" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="6" name="CloseTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="0.424" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterAutoCloseableClose" time="0.344" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterCloseOnInterfaceThatExtendsCloseable" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterCloseableClose" time="0.021" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CloseTest" name="expectIllegalStateExceptionAfterCloseOnInterfaceThatExtendsAutoCloseable" time="0.032" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="7" name="CustomHttpMethodTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.456" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.CustomHttpMethodTest" name="invokesUserDefinedHttpMethod" time="0.456" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="8" name="DefaultExceptionMapperConfigTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="1.567" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperConfigTest" name="testNoExceptionThrownWhenDisabledDuringBuild" time="1.567" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="9" name="DefaultExceptionMapperTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="1.752" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testLowerPriorityMapperTakesPrecedenceFromDefault" time="0.140" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testExceptionThrownWhenPropertySetToFalse" time="1.397" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testPropagationOfResponseDetailsFromDefaultMapper" time="0.102" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperTest" name="testNoExceptionThrownWhenDisabledDuringBuild" time="0.113" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="10" name="DefaultMIMETypeTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="0.353" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultMIMETypeTest" name="testDefaultMIMETypeIsApplicationJson_ContentType" time="0.022" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.DefaultMIMETypeTest" name="testDefaultMIMETypeIsApplicationJson_Accept" time="0.331" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="11" name="ExceptionMapperTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.557" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ExceptionMapperTest" name="testWithTwoRegisteredProviders" time="0.104" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ExceptionMapperTest" name="testWithOneRegisteredProvider" time="1.453" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="12" name="FATSuite" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="639.756" timestamp="2021-07-03T06:08:46">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.RestClientTckPackageTest" name="testRestClientTck" time="637.184" />
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="13" name="FeatureRegistrationTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="0.680" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FeatureRegistrationTest" name="testFeatureRegistrationViaBuilder" time="0.647" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FeatureRegistrationTest" name="testFeatureRegistrationViaCDI" time="0.033" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="14" name="FollowRedirectsTest" package="org.eclipse.microprofile.rest.client.tck" tests="8" time="2.294" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test303Default" time="0.148" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test301Follows" time="0.151" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test307Default" time="0.089" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test303Follows" time="0.113" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test302Follows" time="0.127" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test302Default" time="0.120" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test301Default" time="1.448" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest" name="test307Follows" time="0.098" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="15" name="InheritanceTest" package="org.eclipse.microprofile.rest.client.tck" tests="3" time="0.503" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InheritanceTest" name="canInvokeMethodOnChildInterface" time="0.051" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InheritanceTest" name="canInvokeMethodOnBaseInterface" time="0.406" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InheritanceTest" name="canInvokeOverriddenMethodOnChildInterface" time="0.046" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="16" name="InvalidInterfaceTest" package="org.eclipse.microprofile.rest.client.tck" tests="11" time="0.636" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleClientHeaderParamsSpecifySameHeaderOnInterface" time="0.037" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMultipleHTTPMethodAnnotations" time="0.026" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMismatchedPathParameter" time="0.023" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithPathParamAnnotationButNoURITemplate" time="0.039" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtTypeLevel" time="0.021" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenClientHeaderParamComputeValueSpecifiesMissingMethod" time="0.029" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleClientHeaderParamsSpecifySameHeaderOnMethod" time="0.030" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleHeaderValuesSpecifiedIncludeComputeMethodOnMethod" time="0.031" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtMethodLevel" time="0.027" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenClientHeaderParamComputeValueSpecifiesMethodWithInvalidSignature" time="0.348" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest" name="testExceptionThrownWhenMultipleHeaderValuesSpecifiedIncludeComputeMethodOnInterface" time="0.025" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="17" name="InvokeSimpleGetOperationTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="1.262" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeSimpleGetOperationTest" name="testGetExecutionWithBuiltClient" time="1.262" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="18" name="InvokeWithBuiltProvidersTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.457" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithBuiltProvidersTest" name="testInvokesPostOperationWithRegisteredProviders" time="1.367" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithBuiltProvidersTest" name="testInvokesPutOperationWithRegisteredProviders" time="0.090" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="19" name="InvokeWithJsonPProviderTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="1.464" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testPostExecutes" time="0.138" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testGetSingleExecutesForBothClients" time="0.071" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testPutExecutes" time="0.118" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest" name="testGetExecutesForBothClients" time="1.137" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="20" name="InvokeWithRegisteredProvidersTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.187" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithRegisteredProvidersTest" name="testInvokesPutOperationWithAnnotatedProviders" time="0.050" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokeWithRegisteredProvidersTest" name="testInvokesPostOperationWithAnnotatedProviders" time="1.137" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="21" name="InvokedMethodTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.361" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.InvokedMethodTest" name="testRequestFilterReturnsMethodInvoked" time="0.361" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="22" name="MultiRegisteredTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="1.420" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.MultiRegisteredTest" name="testOverrideInterfaceAndProviderAnnotationOnBuilder" time="1.314" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.MultiRegisteredTest" name="testOverrideProviderAnnotationOnBuilder" time="0.106" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="23" name="ProducesConsumesTest" package="org.eclipse.microprofile.rest.client.tck" tests="2" time="0.390" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProducesConsumesTest" name="testProducesConsumesAnnotationOnMethod" time="0.023" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProducesConsumesTest" name="testProducesConsumesAnnotationOnInterface" time="0.367" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="24" name="ProvidesRestClientBuilderTest" package="org.eclipse.microprofile.rest.client.tck" tests="3" time="0.798" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProvidesRestClientBuilderTest" name="testLastBaseUriOrBaseUrlCallWins" time="0.093" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProvidesRestClientBuilderTest" name="testIllegalStateExceptionThrownWhenNoBaseUriOrUrlSpecified" time="0.061" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProvidesRestClientBuilderTest" name="testCanCallStaticLoader" time="0.644" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="25" name="ProxyServerTest" package="org.eclipse.microprofile.rest.client.tck" tests="5" time="1.821" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testInvalidPortNumber" time="0.843" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testProxy" time="0.805" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testInvalidPortNumber2" time="0.049" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testInvalidPortNumber1" time="0.060" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ProxyServerTest" name="testNullHostName" time="0.064" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="26" name="QueryParamStyleTest" package="org.eclipse.microprofile.rest.client.tck" tests="4" time="0.600" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="explicitMultiPair" time="0.048" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="commaSeparated" time="0.060" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="defaultStyleIsMultiPair" time="0.042" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest" name="arrayPairs" time="0.450" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="27" name="RestClientBuilderListenerTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.430" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.RestClientBuilderListenerTest" name="testRegistrarInvoked" time="0.430" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="28" name="RestClientListenerTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.374" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.RestClientListenerTest" name="testRestClientListenerInvoked" time="0.374" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="29" name="SubResourceTest" package="org.eclipse.microprofile.rest.client.tck" tests="1" time="0.351" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.SubResourceTest" name="canInvokeMethodOnSubResourceInterface" time="0.351" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="30" name="AsyncMethodTest" package="org.eclipse.microprofile.rest.client.tck.asynctests" tests="4" time="2.084" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testNullExecutorServiceThrowsIllegalArgumentException" time="0.117" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testInterfaceMethodWithCompletionStageObjectReturnIsInvokedAsynchronously" time="0.101" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testExecutorService" time="0.138" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest" name="testAsyncInvocationInterceptorProvider" time="1.728" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="31" name="CDIInvokeAsyncSimpleGetOperationTest" package="org.eclipse.microprofile.rest.client.tck.asynctests" tests="2" time="1.326" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.CDIInvokeAsyncSimpleGetOperationTest" name="testInvokesGetOperationWithCDIBean" time="0.574" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.asynctests.CDIInvokeAsyncSimpleGetOperationTest" name="testHasDependentScopedByDefault" time="0.752" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="32" name="CDIClientHeadersFactoryTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="1" time="0.407" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIClientHeadersFactoryTest" name="testClientHeadersFactoryInvoked" time="0.407" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="33" name="CDIFollowRedirectsTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="8" time="2.483" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test303Follows" time="0.107" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test307Follows" time="0.139" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test301Default" time="1.480" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test303Default" time="0.178" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test301Follows" time="0.182" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test307Default" time="0.113" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test302Default" time="0.143" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIFollowRedirectsTest" name="test302Follows" time="0.141" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="34" name="CDIInterceptorTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="2" time="0.484" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInterceptorTest" name="testInterceptorInvoked" time="0.396" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInterceptorTest" name="testInterceptorNotInvokedWhenNoAnnotationApplied" time="0.088" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="35" name="CDIInvokeSimpleGetOperationTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="2" time="1.476" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeSimpleGetOperationTest" name="testInvokesGetOperationWithCDIBean" time="0.646" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeSimpleGetOperationTest" name="testHasDependentScopedByDefault" time="0.830" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="36" name="CDIInvokeWithRegisteredProvidersTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="6" time="2.162" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPostOperation_viaMPConfigWithConfigKey" time="0.157" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPutOperation_viaMPConfigWithConfigKey" time="0.117" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPutOperation_viaMPConfig" time="0.208" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPostOperation_viaMPConfig" time="0.169" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPostOperation_viaAnnotation" time="1.395" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest" name="testInvokesPutOperation_viaAnnotation" time="0.116" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="37" name="CDIManagedProviderTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="4" time="0.821" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testCDIProviderSpecifiedViaAnnotation" time="0.052" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testCDIProviderSpecifiedViaRestClientBuilder" time="0.066" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testCDIProviderSpecifiedInMPConfig" time="0.617" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIManagedProviderTest" name="testInstanceProviderSpecifiedViaRestClientBuilderDoesNotUseCDIManagedProvider" time="0.086" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="38" name="CDIProxyServerTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="1" time="1.543" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIProxyServerTest" name="testProxy" time="1.543" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="39" name="CDIQueryParamStyleTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="4" time="1.008" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="defaultStyleIsMultiPair" time="0.147" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="commaSeparated" time="0.118" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="arrayPairs" time="0.628" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIQueryParamStyleTest" name="explicitMultiPair" time="0.115" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="40" name="CDIURIvsURLConfigTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="3.774" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIURIvsURLConfigTest" name="testMPConfigURIOverridesBaseUriInRegisterRestClientAnnotation" time="0.131" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIURIvsURLConfigTest" name="testBaseUriInRegisterRestClientAnnotation" time="2.135" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.CDIURIvsURLConfigTest" name="testURItakesPrecedenceOverURL" time="1.508" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="41" name="ConfigKeyForMultipleInterfacesTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="1" time="0.507" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.ConfigKeyForMultipleInterfacesTest" name="testConfigKeyUsedForUri" time="0.507" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="42" name="ConfigKeyTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="2" time="0.537" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.ConfigKeyTest" name="testFullyQualifiedClassnamePropTakesPrecedenceOverConfigKey" time="0.105" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.ConfigKeyTest" name="testConfigKeyUsedForUri" time="0.432" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="43" name="HasAppScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.626" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasAppScopeTest" name="testHasApplicationScopedFromConfigKey" time="0.053" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasAppScopeTest" name="testHasApplicationScopedWhenAnnotated" time="0.051" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasAppScopeTest" name="testHasApplicationScoped" time="0.522" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="44" name="HasConversationScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.607" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasConversationScopeTest" name="testHasConversationScopedFromConfigKey" time="0.049" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasConversationScopeTest" name="testHasConversationScoped" time="0.508" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasConversationScopeTest" name="testHasConversationScopedWhenAnnotated" time="0.050" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="45" name="HasRequestScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.449" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasRequestScopeTest" name="testHasRequestScopedWhenAnnotated" time="0.050" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasRequestScopeTest" name="testHasRequestScoped" time="0.354" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasRequestScopeTest" name="testHasRequestScopedFromConfigKey" time="0.045" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="46" name="HasSessionScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.433" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSessionScopeTest" name="testHasSingletonScoped" time="0.042" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSessionScopeTest" name="testHasSessionScopedFromConfigKey" time="0.345" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSessionScopeTest" name="testHasSessionScopedWhenAnnotated" time="0.046" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="47" name="HasSingletonScopeTest" package="org.eclipse.microprofile.rest.client.tck.cditests" tests="3" time="0.415" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSingletonScopeTest" name="testHasSingletonScoped" time="0.324" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSingletonScopeTest" name="testHasSingletonScopedFromConfigKey" time="0.056" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.cditests.HasSingletonScopeTest" name="testHasSingletonScopedWhenAnnotated" time="0.035" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="48" name="InvokeWithJsonBProviderTest" package="org.eclipse.microprofile.rest.client.tck.jsonb" tests="2" time="1.330" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.jsonb.InvokeWithJsonBProviderTest" name="testGetExecutesForBothClients" time="0.064" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.jsonb.InvokeWithJsonBProviderTest" name="testCanSeePrivatePropertiesViaContextResolver" time="1.266" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="49" name="SslContextTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="2" time="1.641" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest" name="shouldFailedMutualSslWithoutSslContext" time="1.106" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest" name="shouldSucceedMutualSslWithValidSslContext" time="0.535" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="50" name="SslHostnameVerifierTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="7" time="2.475" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldSucceedWithAcceptingHostnameVerifier" time="0.298" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldPassSslSessionAndHostnameToHostnameVerifierCDI" time="0.236" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldFailWithRejectingHostnameVerifier" time="0.784" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldSucceedWithAcceptingHostnameVerifierCDI" time="0.189" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldFailWithRejectingHostnameVerifierCDI" time="0.269" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldPassSslSessionAndHostnameToHostnameVerifier" time="0.326" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest" name="shouldFailWithoutHostnameAndNoVerifier" time="0.373" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="51" name="SslMutualTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="7" time="9.079" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithNoClientSignatureCDI" time="1.188" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldWorkWithClientSignatureFromClasspathCDI" time="0.985" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithInvalidClientSignatureCDI" time="1.189" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithNoClientSignature" time="1.241" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldFailWithInvalidClientSignature" time="1.819" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldWorkWithClientSignatureCDI" time="1.014" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest" name="shouldWorkWithClientSignature" time="1.643" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="52" name="SslTrustStoreTest" package="org.eclipse.microprofile.rest.client.tck.ssl" tests="7" time="3.811" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithSelfSignedKeystoreCDI" time="0.582" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldSucceedWithRegisteredSelfSignedKeystore" time="0.557" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldSucceedWithRegisteredSelfSignedKeystoreFromResourceCDI" time="0.467" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldSucceedWithRegisteredSelfSignedKeystoreCDI" time="0.384" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithNonMatchingKeystore" time="0.939" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithNonMatchingKeystoreCDI" time="0.413" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest" name="shouldFailWithSelfSignedKeystore" time="0.469" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="53" name="TimeoutBuilderIndependentOfMPConfigTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="11.407" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest" name="testReadTimeout" time="5.619" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest" name="testConnectTimeout" time="5.788" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="54" name="TimeoutTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="11.565" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest" name="testReadTimeout" time="5.580" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest" name="testConnectTimeout" time="5.985" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="55" name="TimeoutViaMPConfigTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="15.264" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest" name="testReadTimeout" time="7.541" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest" name="testConnectTimeout" time="7.723" />
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="ebcprs2939qmv2cpu-n.fyre.ibm.com" id="56" name="TimeoutViaMPConfigWithConfigKeyTest" package="org.eclipse.microprofile.rest.client.tck.timeout" tests="2" time="15.299" timestamp="3 Jul 2021 06:19:24 GMT">
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest" name="testConnectTimeout" time="7.721" />
+
+      <testcase classname="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest" name="testReadTimeout" time="7.578" />
+
+  </testsuite>
+</testsuites>
+
+----


### PR DESCRIPTION
These are the TCK results from Open Liberty 21.0.0.8-beta which will be used to demonstrate a compatible implementation prior to the final release of MicroProfile 4.1