### PR TITLE
Microprofile GraphQL 2.0 Certification Draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/microprofile/graphql/2.0/22.0.0.4-beta-Java11-TCKResults.adoc
+++ b/microprofile/graphql/2.0/22.0.0.4-beta-Java11-TCKResults.adoc
@@ -1,0 +1,188 @@
+:page-layout: certification 
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile GraphQL 2.0.
+
+== Open Liberty 22.0.0.4-beta - MicroProfile GraphQL 2.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/22.0.0.4-beta/openliberty-runtime-22.0.0.4-beta.zip[Open Liberty 22.0.0.4-beta]
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-graphql-2.0-RC3/microprofile-graphql-spec-2.0-RC3.html[MicroProfile GraphQL 2.0-RC3]
+
+* Public URL of TCK Results Summary:
++
+link:22.0.0.4-beta-Java11-TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 11: OpenJDK Runtime Environment (11.0.5+10)
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Linux (4.15.0-167-generic; amd64)
+
+Test results:
+
+[source, text]
+----
+Test suite: org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest 2022-03-03T11:13:08 CST
+Tests:155 Failures:0 Errors:0
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testResponse Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+----

--- a/microprofile/graphql/2.0/22.0.0.4-beta-Java17-TCKResults.adoc
+++ b/microprofile/graphql/2.0/22.0.0.4-beta-Java17-TCKResults.adoc
@@ -1,0 +1,188 @@
+:page-layout: certification 
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile GraphQL 2.0.
+
+== Open Liberty 22.0.0.4-beta - MicroProfile GraphQL 2.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/22.0.0.4-beta/openliberty-runtime-22.0.0.4-beta.zip[Open Liberty 22.0.0.4-beta]
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-graphql-2.0-RC3/microprofile-graphql-spec-2.0-RC3.html[MicroProfile GraphQL 2.0-RC3]
+
+* Public URL of TCK Results Summary:
++
+link:22.0.0.4-beta-Java17-TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 17: OpenJDK Runtime Environment (17+35-2724)
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Linux (4.15.0-167-generic; amd64)
+
+Test results:
+
+[source, text]
+----
+Test suite: org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest 2022-03-02T17:06:44 CST
+Tests:155 Failures:0 Errors:0
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testResponse Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+----

--- a/microprofile/graphql/2.0/22.0.0.4-beta-Java8-TCKResults.adoc
+++ b/microprofile/graphql/2.0/22.0.0.4-beta-Java8-TCKResults.adoc
@@ -1,0 +1,188 @@
+:page-layout: certification 
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile GraphQL 2.0.
+
+== Open Liberty 22.0.0.4-beta - MicroProfile GraphQL 2.0 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/22.0.0.4-beta/openliberty-runtime-22.0.0.4-beta.zip[Open Liberty 22.0.0.4-beta]
+* Specification Name, Version and download URL:
++
+link:https://download.eclipse.org/microprofile/microprofile-graphql-2.0-RC3/microprofile-graphql-spec-2.0-RC3.html[MicroProfile GraphQL 2.0-RC3]
+
+* Public URL of TCK Results Summary:
++
+link:22.0.0.4-beta-Java8-TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+Java 8: OpenJDK Runtime Environment (1.8.0_252-b09
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Linux (4.15.0-167-generic; amd64)
+
+Test results:
+
+[source, text]
+----
+Test suite: org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest 2022-03-03T14:43:39 CST
+Tests:155 Failures:0 Errors:0
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testResponse Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+   org.eclipse.microprofile.graphql.tck.dynamic.SchemaDynamicValidityTest.testPartsOfSchema Passed!
+----


### PR DESCRIPTION
Uploading the 3 TCK results (Java 8, 11 and 17) for mpGraphQL-2.0

I also included an additional commit to create a `.gitignore` file to ignore `.DS_Store` system files on MacOS.