### PR TITLE
Use MP6 zip

### DIFF
--- a/microprofile/6.0/23.0.0.3-TCKResults.adoc
+++ b/microprofile/6.0/23.0.0.3-TCKResults.adoc
@@ -27,7 +27,7 @@ MicroProfile 6.0 consists of 8 MicroProfile Specifications plus the Jakarta EE C
 
 === Product Name, Version and download URL (if applicable):
 
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 
 In order to certify against MicroProfile 6.0, an implementation must pass the TCK tests for the eight included MicroProfile component specifications, plus

--- a/microprofile/6.0/23.0.0.3-TCKResults.adoc
+++ b/microprofile/6.0/23.0.0.3-TCKResults.adoc
@@ -7,6 +7,8 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 MicroProfile 6.0 consists of 8 MicroProfile Specifications plus the Jakarta EE Core Profile 10.0 specfication.
 
+* Jakarta EE Core Profile 10.0
+
 * MicroProfile Config 3.0
 
 * MicroProfile Fault Tolerance 4.0
@@ -23,8 +25,6 @@ MicroProfile 6.0 consists of 8 MicroProfile Specifications plus the Jakarta EE C
 
 * MicroProfile Telemetry 1.0
 
-* Jakarta EE Core Profile 10.0
-
 === Product Name, Version and download URL (if applicable):
 
 https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
@@ -35,6 +35,7 @@ the Jakarta EE Core Profile 10.0 TCK.
 
 
 === MicroProfile 6.0 Component Specification Certification Summary (Java 11)
+* xref:../../jakartaee/10/coreprofile/23.0.0.3-Java11-TCKResults.adoc[Jakarta EE Core Profile 10.0 TCK Result (Java 11)]
 * xref:config/3.0.2/23.0.0.3-Config-3.0.2-Java11-TCKResults.adoc[MicroProfile Config 3.0 TCK Result (Java 11)]
 * xref:faulttolerance/4.0.2/23.0.0.3-Fault-Tolerance-4.0.2-Java11-TCKResults.adoc[MicroProfile Fault Tolerance 4.0 TCK Result (Java 11)]
 * xref:health/4.0.1/23.0.0.3-Health-4.0.1-Java11-TCKResults.adoc[MicroProfile Health 4.0 TCK Result (Java 11)]
@@ -43,9 +44,9 @@ the Jakarta EE Core Profile 10.0 TCK.
 * xref:openapi/3.1/23.0.0.3-Open-API-3.1-Java11-TCKResults.adoc[MicroProfile OpenAPI 3.1 TCK Result (Java 11)]
 * xref:restclient/3.0.1/23.0.0.3-Rest-Client-3.0.1-Java11-TCKResults.adoc[MicroProfile Rest Client 3.0 TCK Result (Java 11)]
 * xref:telemetry/1.0/23.0.0.3-Telemetry-1.0-Java11-TCKResults.adoc[MicroProfile Telemetry 1.0 TCK Result (Java 11)]
-* xref:../../jakartaee/10/coreprofile/23.0.0.3-Java11-TCKResults.adoc[Jakarta EE Core Profile 10.0 TCK Result (Java 11)]
 
 === MicroProfile 6.0 Component Specification Certification Summary (Java 17)
+* xref:../../jakartaee/10/coreprofile/23.0.0.3-Java17-TCKResults.adoc[Jakarta EE Core Profile 10.0 TCK Result (Java 17)]
 * xref:config/3.0.2/23.0.0.3-Config-3.0.2-Java17-TCKResults.adoc[MicroProfile Config 3.0 TCK Result (Java 17)]
 * xref:faulttolerance/4.0.2/23.0.0.3-Fault-Tolerance-4.0.2-Java17-TCKResults.adoc[MicroProfile Fault Tolerance 4.0 TCK Result (Java 17)]
 * xref:health/4.0.1/23.0.0.3-Health-4.0.1-Java17-TCKResults.adoc[MicroProfile Health 4.0 TCK Result (Java 17)]
@@ -54,4 +55,3 @@ the Jakarta EE Core Profile 10.0 TCK.
 * xref:openapi/3.1/23.0.0.3-Open-API-3.1-Java17-TCKResults.adoc[MicroProfile OpenAPI 3.1 TCK Result (Java 17)]
 * xref:restclient/3.0.1/23.0.0.3-Rest-Client-3.0.1-Java17-TCKResults.adoc[MicroProfile Rest Client 3.0 TCK Result (Java 17)]
 * xref:telemetry/1.0/23.0.0.3-Telemetry-1.0-Java17-TCKResults.adoc[MicroProfile Telemetry 1.0 TCK Result (Java 17)]
-* xref:../../jakartaee/10/coreprofile/23.0.0.3-Java17-TCKResults.adoc[Jakarta EE Core Profile 10.0 TCK Result (Java 17)]

--- a/microprofile/6.0/config/3.0.2/23.0.0.3-Config-3.0.2-Java11-TCKResults.adoc
+++ b/microprofile/6.0/config/3.0.2/23.0.0.3-Config-3.0.2-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/config/3.0.2/23.0.0.3-Config-3.0.2-Java17-TCKResults.adoc
+++ b/microprofile/6.0/config/3.0.2/23.0.0.3-Config-3.0.2-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/faulttolerance/4.0.2/23.0.0.3-Fault-Tolerance-4.0.2-Java11-TCKResults.adoc
+++ b/microprofile/6.0/faulttolerance/4.0.2/23.0.0.3-Fault-Tolerance-4.0.2-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/faulttolerance/4.0.2/23.0.0.3-Fault-Tolerance-4.0.2-Java17-TCKResults.adoc
+++ b/microprofile/6.0/faulttolerance/4.0.2/23.0.0.3-Fault-Tolerance-4.0.2-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/health/4.0.1/23.0.0.3-Health-4.0.1-Java11-TCKResults.adoc
+++ b/microprofile/6.0/health/4.0.1/23.0.0.3-Health-4.0.1-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/health/4.0.1/23.0.0.3-Health-4.0.1-Java17-TCKResults.adoc
+++ b/microprofile/6.0/health/4.0.1/23.0.0.3-Health-4.0.1-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/jwt/2.1/23.0.0.3-JWT-Auth-2.1-Java11-TCKResults.adoc
+++ b/microprofile/6.0/jwt/2.1/23.0.0.3-JWT-Auth-2.1-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/jwt/2.1/23.0.0.3-JWT-Auth-2.1-Java17-TCKResults.adoc
+++ b/microprofile/6.0/jwt/2.1/23.0.0.3-JWT-Auth-2.1-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/metrics/5.0.0/23.0.0.3-Metrics-5.0.0-Java11-TCKResults.adoc
+++ b/microprofile/6.0/metrics/5.0.0/23.0.0.3-Metrics-5.0.0-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/metrics/5.0.0/23.0.0.3-Metrics-5.0.0-Java17-TCKResults.adoc
+++ b/microprofile/6.0/metrics/5.0.0/23.0.0.3-Metrics-5.0.0-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/openapi/3.1/23.0.0.3-Open-API-3.1-Java11-TCKResults.adoc
+++ b/microprofile/6.0/openapi/3.1/23.0.0.3-Open-API-3.1-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/openapi/3.1/23.0.0.3-Open-API-3.1-Java17-TCKResults.adoc
+++ b/microprofile/6.0/openapi/3.1/23.0.0.3-Open-API-3.1-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/restclient/3.0.1/23.0.0.3-Rest-Client-3.0.1-Java11-TCKResults.adoc
+++ b/microprofile/6.0/restclient/3.0.1/23.0.0.3-Rest-Client-3.0.1-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/restclient/3.0.1/23.0.0.3-Rest-Client-3.0.1-Java17-TCKResults.adoc
+++ b/microprofile/6.0/restclient/3.0.1/23.0.0.3-Rest-Client-3.0.1-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/telemetry/1.0/23.0.0.3-Telemetry-1.0-Java11-TCKResults.adoc
+++ b/microprofile/6.0/telemetry/1.0/23.0.0.3-Telemetry-1.0-Java11-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/6.0/telemetry/1.0/23.0.0.3-Telemetry-1.0-Java17-TCKResults.adoc
+++ b/microprofile/6.0/telemetry/1.0/23.0.0.3-Telemetry-1.0-Java17-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-23.0.0.3.zip[Open Liberty 23.0.0.3]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/23.0.0.3/openliberty-microProfile6-23.0.0.3.zip[Open Liberty 23.0.0.3]
 
 * Specification Name, Version and download URL:
 +


### PR DESCRIPTION
- Use the MP6 specific zip rather than the full OL zip
- List Core Profile before the MP specs