### PR TITLE
Fixing TCK Links for Open-API and JWT-Auth

### DIFF
--- a/microprofile/6.1/jwt/2.1/23.0.0.12-MicroProfile-JWT-Auth-2.1-Java11-TCKResults.adoc
+++ b/microprofile/6.1/jwt/2.1/23.0.0.12-MicroProfile-JWT-Auth-2.1-Java11-TCKResults.adoc
@@ -15,7 +15,7 @@ https://github.com/eclipse/microprofile-jwt-auth/tree/2.1[MicroProfile JWT Auth 
 
 * (Optional) TCK Version, digital fingerprint and download URL:
 +
-https://repo1.maven.org/maven2/org/eclipse/microprofile/jwt-auth/microprofile-jwt-auth-tck/2.1/microprofile-jwt-auth-tck-2.1.jar[MicroProfile JWT Auth 2.1 TCK]
+https://repo1.maven.org/maven2/org/eclipse/microprofile/jwt/microprofile-jwt-auth-tck/2.1/microprofile-jwt-auth-tck-2.1.jar[MicroProfile JWT Auth 2.1 TCK]
 +
 SHA-1: `ccb29d4d588628fa46c61c85499284ab9b22bee1`
 +

--- a/microprofile/6.1/jwt/2.1/23.0.0.12-MicroProfile-JWT-Auth-2.1-Java17-TCKResults.adoc
+++ b/microprofile/6.1/jwt/2.1/23.0.0.12-MicroProfile-JWT-Auth-2.1-Java17-TCKResults.adoc
@@ -15,7 +15,7 @@ https://github.com/eclipse/microprofile-jwt-auth/tree/2.1[MicroProfile JWT Auth 
 
 * (Optional) TCK Version, digital fingerprint and download URL:
 +
-https://repo1.maven.org/maven2/org/eclipse/microprofile/jwt-auth/microprofile-jwt-auth-tck/2.1/microprofile-jwt-auth-tck-2.1.jar[MicroProfile JWT Auth 2.1 TCK]
+https://repo1.maven.org/maven2/org/eclipse/microprofile/jwt/microprofile-jwt-auth-tck/2.1/microprofile-jwt-auth-tck-2.1.jar[MicroProfile JWT Auth 2.1 TCK]
 +
 SHA-1: `ccb29d4d588628fa46c61c85499284ab9b22bee1`
 +

--- a/microprofile/6.1/openapi/3.1/23.0.0.12-MicroProfile-Open-API-3.1-Java11-TCKResults.adoc
+++ b/microprofile/6.1/openapi/3.1/23.0.0.12-MicroProfile-Open-API-3.1-Java11-TCKResults.adoc
@@ -15,7 +15,7 @@ https://github.com/eclipse/microprofile-open-api/tree/3.1[MicroProfile Open API 
 
 * (Optional) TCK Version, digital fingerprint and download URL:
 +
-https://repo1.maven.org/maven2/org/eclipse/microprofile/open-api/microprofile-open-api-tck/3.1/microprofile-open-api-tck-3.1.jar[MicroProfile Open API 3.1 TCK]
+https://repo1.maven.org/maven2/org/eclipse/microprofile/openapi/microprofile-openapi-tck/3.1/microprofile-openapi-tck-3.1.jar[MicroProfile Open API 3.1 TCK]
 +
 SHA-1: `3f6b0031b5c5563c060c29437f5e910f0b4a13f2`
 +

--- a/microprofile/6.1/openapi/3.1/23.0.0.12-MicroProfile-Open-API-3.1-Java17-TCKResults.adoc
+++ b/microprofile/6.1/openapi/3.1/23.0.0.12-MicroProfile-Open-API-3.1-Java17-TCKResults.adoc
@@ -15,7 +15,7 @@ https://github.com/eclipse/microprofile-open-api/tree/3.1[MicroProfile Open API 
 
 * (Optional) TCK Version, digital fingerprint and download URL:
 +
-https://repo1.maven.org/maven2/org/eclipse/microprofile/open-api/microprofile-open-api-tck/3.1/microprofile-open-api-tck-3.1.jar[MicroProfile Open API 3.1 TCK]
+https://repo1.maven.org/maven2/org/eclipse/microprofile/openapi/microprofile-openapi-tck/3.1/microprofile-openapi-tck-3.1.jar[MicroProfile Open API 3.1 TCK]
 +
 SHA-1: `3f6b0031b5c5563c060c29437f5e910f0b4a13f2`
 +


### PR DESCRIPTION
The current "TCK Version, digital fingerprint and download URL" links are incorrect for MicroProfile Open-API and JWT Auth.