### PR TITLE
Updated Concurrency 3.1 Certification Results to Staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Reference the [sample TCKResults](./TCKResults.adoc) file for an example of the 
  
    In the PR, provide a link to your page on the [certifications-draft site](https://certifications-draft-openlibertyio.mybluemix.net/) or [draft site](https://draft-openlibertyio.mybluemix.net/). Ideally, also paste a screenshot of the entire Certification/TCK Result page as this will allow reviewers to see the rendered content even while the sites are innaccessible (e.g. during redeploys).
    
-   Add @mbroz2 or another admin to get their final approval for both content and format.
+   Add the [Release Architect](https://github.com/orgs/OpenLiberty/teams/release-architect) or another admin to get their final approval for both content and format.
    
    As before, make any changes in your feature branch, create a PR `draft` branch, get it merged, and once the site rebuilds, check that everything is correct on the [certifications-draft site](https://certifications-draft-openlibertyio.mybluemix.net/) or [draft site](https://draft-openlibertyio.mybluemix.net/).
 
@@ -87,7 +87,7 @@ These steps are completed by the admins of this repo. They might ask questions o
    
    Make any changes in the author's branch, and push to both `draft` and `staging`.
    
-6. To publish the content, create a PR from `staging` branch to `prod` branch and add @mbroz2 (or other admin) as approver.
+6. To publish the content, create a PR from `staging` branch to `prod` branch and add the [Release Architect](https://github.com/orgs/OpenLiberty/teams/release-architect) (or other admin) as approver.
 
 7. When the PR is approved, merge it into `prod`.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Reference the [sample TCKResults](./TCKResults.adoc) file for an example of the 
 
 5. Push the file to GitHub (if you're a member of this org, feel free to push your branch to the certification repo instead of using a fork), then create a pull request (PR) into the `draft` branch.
 
-6. Request a code review.  The code review can be from anyone, however, you should consider including @mbroz2, @Emily-Jiang (for MicroProfile), @jhanders34 (for Jakarta EE), or @tevans78 (for MicroProfile/Jakarta EE).  Once the PR has been approved, merge it into `draft`.
+6. Request a code review.  The code review can be from anyone, however, you should consider including the [Release Architect](https://github.com/orgs/OpenLiberty/teams/release-architect), @Emily-Jiang (for MicroProfile), @jhanders34 (for Jakarta EE), or @tevans78 (for MicroProfile/Jakarta EE).  Once the PR has been approved, merge it into `draft`.
 
 6. All the builds and deployments of non-prod sites are on IBM Cloud and build automatically whenever a PR is merged into their respective branch. These builds are private and, therefore, their detailed build/deploy progress can't be tracked. However, if you have access to the [Slack channel for draft site](https://app.slack.com/client/T15GKHBT4/C01G7L68KAP) or the [Slack channel for staging site](https://app.slack.com/client/T15GKHBT4/C01GX9P8YP2), you can at least track when the builds start and finish.
 

--- a/jakartaee/11/concurrency/24.0.0.6-beta-Java17-TCKResults.adoc
+++ b/jakartaee/11/concurrency/24.0.0.6-beta-Java17-TCKResults.adoc
@@ -15,7 +15,7 @@ https://jakarta.ee/specifications/concurrency/3.1[Jakarta EE Concurrency 3.1]
 
 * TCK Version, digital SHA-256 fingerprint and download URL:
 +
-https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.zip[Jakarta EE Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.info[SHA-256]: `7b79bba4167530eb899fecb225e597346c3957f37b3b05bd825d7ab1d58512bd`
+https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.zip[Jakarta EE Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.info[SHA-256]: `ad1d52fdf9648db8d2afbaefd480d8995be47b59c605b439d69ededf4da4fcd5`
 
 * Public URL of TCK Results Summary:
 +
@@ -46,388 +46,683 @@ Test results:
 ----
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="49.095" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="2.412">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.126">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.095">
+  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="56.244" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="3.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.145">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.155">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringThrowableTest" time="0.132">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="14.31" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.008">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.15">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.208">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.174">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.136">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.149">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.141">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.162">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.149">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.145">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.131">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.101">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.114">
+  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="17.434" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.403">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.164">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.196">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.165">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.151">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.242">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.152">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.238">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.15">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.164">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.175">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.15">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.178">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.259">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="20.944" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="2.068">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.082">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="2.091">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.074">
+  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="20.325" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="2.28">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.126">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="1.157">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.124">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="9.361" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="1.215">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.156">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithMapAndNullArg" time="0.106">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.157">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.104">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.118">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.098">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.106">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.134">
+  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="10.331" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="0.907">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.117">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithMapAndNullArg" time="0.095">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.155">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.136">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.115">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.084">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.129">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.195">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.172">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="7.09" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="0.859">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.063">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.044">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.083">
+  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="8.518" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="1.441">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.115">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.109">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.121">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="5.29" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="0.856">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.054">
+  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="6.947" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="1.13">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.076">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="11.953" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="0.672">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.052">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="1.043">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="2.055">
+  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="13.37" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="1.052">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.111">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="0.164">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="2.177">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="6.0" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="0.652">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.043">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.056">
+  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="7.963" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="1.209">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.144">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.129">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="4.36" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.569">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.034">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.046">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.035">
+  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="4.871" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.65">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.056">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.084">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.092">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="21.458" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.463">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.039">
+  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="22.018" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.958">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.051">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="8.483" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="9.572" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.987">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.097">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.207">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.03">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="1.008">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.075">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.084">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.032">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.068">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.185">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.028">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.154">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="1.732">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.044">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.036">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.052">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.064">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.024">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionAllAttributes" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.022">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="1.38">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.039">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.063">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.027">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.09">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.067">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.041">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionAllAttributes" time="0.034">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.063">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="5.879" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="6.387" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.11">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.026">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.079">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.03">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInEJB" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.06">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.057">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.074">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.052">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.098">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.09">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.466">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.074">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.073">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.511">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.083">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.098">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.118">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.098">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.069">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.083">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.032">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.071">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="10.723" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.277">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.056">
+  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="13.646" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.271">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.658">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="7.538" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="3.309">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.129">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.119">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.222">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.117">
+  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="7.995" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="3.302">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.167">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.18">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.095">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.109">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="13.055" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="0.603">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.053">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.05">
+  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="13.713" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="0.677">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.07">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.069">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.06">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.556" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.733">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.041">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.071">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.041">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.071">
+  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="5.525" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.988">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.105">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.063">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.09">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.082">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.647" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.53">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.08">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.05">
+  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.512" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.602">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.076">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.049">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.089">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.132">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.076">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="98.497" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.114">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="11.519">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.958">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="14.996">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.057">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.827">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.015">
+  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="98.187" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.144">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="12.952">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.031">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.965">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="12.995">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.112">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.067">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.064">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.094">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.625">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.017">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFuture" time="0.013">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.015">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.015">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionDefaults" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.896">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.025">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.888">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.017">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="98.976" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.089">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.221">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.981">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="13.996">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.017">
+  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="101.873" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.068">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="14.528">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.053">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.933">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="14.996">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.02">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFuture" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.032">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.906">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.023">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.034">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.897">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.015">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.881">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFutureEJB" time="0.019">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.893">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFutureEJB" time="0.152">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.347" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.308" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityFullTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.895" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.4" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityWebTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="4.951" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="1.449">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.015">
+  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="4.902" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="1.542">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.022">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.024">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.742" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.606">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.048">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="1.061">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSubmit" time="3.042">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.036">
+  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.585" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.696">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.076">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="1.072">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.076">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSubmit" time="3.065">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.07">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.357" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.504">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.06">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSchedule" time="4.046">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.036">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.037">
+  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.568" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.823">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.043">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSchedule" time="4.056">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.039">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.049">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.05">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.469" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.545">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="0.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.049">
+  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.443" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.609">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.053">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.047">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="0.044">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.041">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.041">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.05">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.479" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.479">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.061">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.038">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.068">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.038">
+  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.509" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="1.037">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.098">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.126">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.073">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.101">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.385" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.453">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.07">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.044">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.072">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.038">
+  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="3.977" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.467">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.033">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.069">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.059">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="105.312" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.054">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="12.872">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.974">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="0.676">
+  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="102.852" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.079">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.019">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.027">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.065">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="12.404">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.015">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.982">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.031">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="0.162">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="12.305">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSE" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.17">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.025">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.757">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.025">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="5.958">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="4.68">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.797">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSE" time="0.01">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.192">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.046">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.029">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.714">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="5.966">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.011">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="1.994">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="104.779" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.049">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodRunsWithContext" time="0.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodWithMaxAsync3" time="1.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="12.153">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.985">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.619">
+  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="106.16" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.036">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodRunsWithContext" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodWithMaxAsync3" time="1.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.024">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="14.108">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.979">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.698">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="14.36">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSE" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.369">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.027">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="13.57">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="12.282">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSE" time="0.023">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.937">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.04">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="12.969">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="5.97">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="1.982">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="4.973">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.011">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="3.711">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.341" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.301" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityFullTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.022" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.532" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityWebTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.907" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.331">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.019">
+  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.834" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.649">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.02">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.415" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.015">
+  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.457" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.036">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.023">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.434" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.013">
+  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="3.913" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.031">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.012">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.492" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.387" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.111">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.108">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.022">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.328" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="4.861" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.05">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.054">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.017">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="8.384" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.274">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.022">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testRollbackTransactionWithManagedThreadFactory" time="1.011">
+  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="7.418" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.369">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testRollbackTransactionWithManagedThreadFactory" time="1.008">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.74" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.61" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.135">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedContextServiceQualifiers" time="0.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.019">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.159">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.025">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.033">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedContextServiceQualifiers" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.02">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.615" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.799" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.015">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.077">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.016">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesContextService" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.009">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.017">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.384" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.069">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.016">
+  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.529" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.057">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.014">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.012">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.012">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.401" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.07">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.018">
+  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.916" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.072">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.019">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.012">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.011">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.035">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.017">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="2.893" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="2.891" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformScheduledExecutor" time="0.026">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformExecutor" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.028">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.057">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.01">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.045">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.016">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="3.432" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="0.014">
+  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="3.395" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.024">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="0.012">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactory" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.024">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.011">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.01">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="13.201" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="5.175">
+  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="17.146" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="6.656">
+      </testcase>
   </testsuite>
 </testsuites>
 ----

--- a/jakartaee/11/concurrency/24.0.0.6-beta-Java21-TCKResults.adoc
+++ b/jakartaee/11/concurrency/24.0.0.6-beta-Java21-TCKResults.adoc
@@ -15,7 +15,7 @@ https://jakarta.ee/specifications/concurrency/3.1[Jakarta EE Concurrency 3.1]
 
 * TCK Version, digital SHA-256 fingerprint and download URL:
 +
-https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.zip[Jakarta EE Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.info[SHA-256]: `7b79bba4167530eb899fecb225e597346c3957f37b3b05bd825d7ab1d58512bd`
+https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.zip[Jakarta EE Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.info[SHA-256]: `ad1d52fdf9648db8d2afbaefd480d8995be47b59c605b439d69ededf4da4fcd5`
 
 * Public URL of TCK Results Summary:
 +
@@ -46,388 +46,683 @@ Test results:
 ----
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="61.369" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="2.973">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.144">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.153">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringThrowableTest" time="0.157">
+  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="59.079" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="2.296">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.146">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.147">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringThrowableTest" time="0.144">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="18.14" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.324">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.234">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.163">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.178">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.142">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.176">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.2">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.201">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.222">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.166">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.2">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.195">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.184">
+  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="17.208" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.215">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.188">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.184">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.139">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.167">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.137">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.158">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.172">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.129">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.175">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.199">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.199">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.197">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.142">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="23.446" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="2.227">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.097">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="2.075">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.156">
+  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="21.432" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="2.066">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.117">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="2.082">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.12">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="10.99" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="1.099">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.114">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithMapAndNullArg" time="0.109">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.124">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.142">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.139">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.15">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.106">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.199">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.168">
+  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="10.328" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="1.112">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.121">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithMapAndNullArg" time="0.118">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.151">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.143">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.165">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.113">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.117">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.122">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.125">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="7.429" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="1.204">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.173">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.12">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.163">
+  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="6.913" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="1.032">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.053">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.103">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.047">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="7.263" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="1.119">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.096">
+  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="6.943" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="0.964">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.087">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="13.941" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="1.102">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.171">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="1.107">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="2.083">
+  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="13.422" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="1.088">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.087">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="1.069">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="2.067">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="6.827" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="0.915">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.058">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.108">
+  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="6.388" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="0.749">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.09">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.097">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="5.558" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.699">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.07">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.093">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.054">
+  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="5.807" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.721">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.133">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.102">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.098">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="23.434" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.674">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.056">
+  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="23.958" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.91">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.048">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="9.944" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="8.038" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.937">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.05">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.19">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.033">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.742">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.024">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.108">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.027">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.088">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.207">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.063">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.152">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="2.405">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.039">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.05">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.141">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.11">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.03">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.079">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionAllAttributes" time="0.084">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.082">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="1.604">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.038">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.03">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.073">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.035">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.083">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.082">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionAllAttributes" time="0.025">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.074">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="6.403" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="6.821" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.085">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.068">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.176">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.034">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInEJB" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.034">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.068">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.093">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.081">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.125">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.076">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.715">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.063">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.081">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.025">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.097">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.076">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.071">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.028">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.068">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.636">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.042">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.092">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.096">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.094">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.03">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.077">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.095">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.087">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="13.206" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.184">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.066">
+  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="12.992" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.132">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.073">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="6.978" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="2.583">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.132">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.111">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.115">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.14">
+  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="7.769" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="2.513">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.173">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.11">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.143">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.093">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="14.105" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="1.232">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.088">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.062">
+  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="13.467" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="0.562">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.083">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.049">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="5.425" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.678">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.054">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.08">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.085">
+  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.869" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.534">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.067">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.095">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.09">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.121">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="5.5" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.75">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.057">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.085">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.077">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.075">
+  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.467" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.732">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.085">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.095">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.057">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="100.496" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.137">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="14.636">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.965">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.998">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.085">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.038">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.783">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFuture" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.017">
+  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="98.04" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.105">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="13.395">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.029">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.962">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.0">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.072">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.092">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.792">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFuture" time="0.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.021">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionDefaults" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.879">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionDefaults" time="0.015">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.011">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.894">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.018">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="99.09" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.878">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.97">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="12.997">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.024">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFuture" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.042">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.872">
+  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="95.966" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.063">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="10.113">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.977">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="14.0">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.026">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFuture" time="0.043">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.048">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.079">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.797">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.022">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.023">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.878">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFutureEJB" time="0.019">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.015">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.015">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.877">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFutureEJB" time="0.02">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.39" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.378" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityFullTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.453" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.947" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityWebTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="5.39" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="1.543">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.03">
+  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="5.383" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="1.548">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.024">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.043">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.528" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.613">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="1.067">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.041">
+  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.442" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.572">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.052">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="1.066">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.061">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSubmit" time="3.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.04">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.055">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.027" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.554">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.045">
+  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.458" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.689">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.059">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSchedule" time="4.051">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.051">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.042">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.037">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.039">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.039">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.054">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.039">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.049" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.545">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="0.061">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.053">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.035">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.046">
+  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.285" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.549">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.056">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.056">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="1.067">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.047">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.044">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.384" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.6">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.06">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.069">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.067">
+  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="3.905" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.455">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.059">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.042">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.066">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.076">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.394" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.569">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.086">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.052">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.08">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.089">
+  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="3.902" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.536">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.057">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.067">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.037">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.074">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="105.09" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.057">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.074">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="13.519">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.032">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.959">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.088">
+  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="102.404" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.113">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.029">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.043">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="12.187">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.973">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="0.896">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.894">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSE" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.089">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.035">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.06">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.792">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="5.922">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="1.985">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="12.083">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSE" time="0.011">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.4">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.023">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.033">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.528">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="4.967">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.983">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="105.084" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.048">
+  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="102.273" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.059">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodRunsWithContext" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodWithMaxAsync3" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.022">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.497">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.986">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.101">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodWithMaxAsync3" time="1.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.029">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="10.268">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.979">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="2.916">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="13.885">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="12.065">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSE" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.09">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="0.023">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.017">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="13.833">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.904">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="4.97">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.988">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="4.963">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="3.161">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.386" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.382" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityFullTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.341" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.423" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityWebTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.92" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.425">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.024">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.014">
+  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.91" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.457">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.017">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.417" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.016">
+  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.44" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.035">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.05">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.388" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.034">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.013">
+  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.43" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.085">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.014">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.416" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.367" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.122">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.064">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.053">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="4.077" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.412" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.054">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.077">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.02">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="7.916" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.427">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testRollbackTransactionWithManagedThreadFactory" time="1.009">
+  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="7.906" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.332">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.017">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testRollbackTransactionWithManagedThreadFactory" time="1.013">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.514" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.803" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedContextServiceQualifiers" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.028">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.163">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.031">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.02">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.062">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedContextServiceQualifiers" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.017">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.475" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="6.104" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.051">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.032">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesContextService" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.135">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesContextService" time="0.009">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.062">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.02">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.608" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.056">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.025">
+  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.563" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.099">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.032">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.013">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.013">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.011">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.049">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.846" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.053">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.029">
+  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="6.189" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.051">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.021">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.016">
+      </testcase>
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.04">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.025">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.015">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.035">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="7.406" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformScheduledExecutor" time="0.029">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformExecutor" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="4.126">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.022">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.02">
+  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="8.117" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformScheduledExecutor" time="0.027">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformExecutor" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="4.041">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.014">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.016">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.01">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.017">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="7.438" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.022">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="4.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactory" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.009">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.016">
+  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="7.856" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.019">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="4.047">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactory" time="0.012">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.018">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.013">
+      </testcase>
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.014">
+      </testcase>
   </testsuite>
-  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="16.955" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="7.405">
+  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="16.599" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="6.597">
+      </testcase>
   </testsuite>
 </testsuites>
 ----


### PR DESCRIPTION
Updated pages:
https://certifications-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/certifications/jakartaee/11/concurrency/24.0.0.6-beta-Java17-TCKResults.html
https://certifications-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/certifications/jakartaee/11/concurrency/24.0.0.6-beta-Java21-TCKResults.html

Both pages should have the SHA from the new build of the TCK -- `ad1d52fdf9648db8d2afbaefd480d8995be47b59c605b439d69ededf4da4fcd5`