### PR TITLE
Add Concurrency 3.1 & Data 1.0 Results for Certification

### DIFF
--- a/jakartaee/11/concurrency/24.0.0.6-beta-Java17-TCKResults.adoc
+++ b/jakartaee/11/concurrency/24.0.0.6-beta-Java17-TCKResults.adoc
@@ -1,21 +1,21 @@
 :page-layout: certification 
 = TCK Results
 
-As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta EE Concurrency.
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta Concurrency.
 
-== Open Liberty 24.0.0.6-beta - Jakarta EE Concurrency Certification Summary (Java 17)
+== Open Liberty 24.0.0.6-beta - Jakarta Concurrency Certification Summary (Java 17)
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-04-23_2000/openliberty-24.0.0.6-beta-cl240520240423-2000.zip[Open Liberty 24.0.0.6-beta]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-05-06_1951/openliberty-24.0.0.6-beta.zip[Open Liberty 24.0.0.6-beta]
 
 * Specification Name, Version and download URL:
 +
-https://jakarta.ee/specifications/concurrency/3.1[Jakarta EE Concurrency 3.1]
+https://jakarta.ee/specifications/concurrency/3.1[Jakarta Concurrency 3.1]
 
 * TCK Version, digital SHA-256 fingerprint and download URL:
 +
-https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.zip[Jakarta EE Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.info[SHA-256]: `7b79bba4167530eb899fecb225e597346c3957f37b3b05bd825d7ab1d58512bd`
+https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.zip[Jakarta Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.info[SHA-256]: `a519066b945b6a10ca1a634c9158c038c2e6f52db6c96e988e977740e1fedc56`
 
 * Public URL of TCK Results Summary:
 +
@@ -34,7 +34,7 @@ JCL      - df9b7169bff based on jdk-17.0.4.1+1)
 
 * Summary of the information for the certification environment, operating system, cloud, ...:
 +
-Ubuntu (5.4.0-176-generic)
+Ubuntu (5.15.0-107-generic)
 
 Test results:
 
@@ -46,388 +46,388 @@ Test results:
 ----
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="49.095" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="2.412">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.126">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.095">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringThrowableTest" time="0.132">
+  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="52.241" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="2.504">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.099">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.058">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringThrowableTest" time="0.158">
   </testsuite>
-  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="14.31" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.008">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.15">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.208">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.174">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.136">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.149">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.141">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.162">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.149">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.145">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.131">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.101">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.114">
+  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="15.304" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.163">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.212">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.116">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.112">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.124">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.16">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.125">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.111">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.144">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.141">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.116">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.162">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.133">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.115">
   </testsuite>
-  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="20.944" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="2.068">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.082">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="2.091">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.074">
+  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="20.484" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="1.943">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.069">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="2.096">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.113">
   </testsuite>
-  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="9.361" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="1.215">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.156">
+  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="9.81" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="0.966">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.119">
       <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithMapAndNullArg" time="0.106">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.157">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.104">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.118">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.098">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.106">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.134">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.154">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.111">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.061">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.085">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.101">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.15">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.095">
   </testsuite>
-  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="7.09" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="0.859">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.063">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.044">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.083">
+  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="5.895" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="0.976">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.055">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.081">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.085">
   </testsuite>
-  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="5.29" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="0.856">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.054">
+  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="5.942" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="0.765">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.057">
   </testsuite>
-  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="11.953" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="0.672">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.052">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="1.043">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="2.055">
+  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="11.425" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="0.741">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.08">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="0.074">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="1.091">
   </testsuite>
-  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="6.0" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="0.652">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.043">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.056">
+  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="5.288" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="0.577">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.048">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.045">
   </testsuite>
-  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="4.36" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.569">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.034">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.046">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.035">
+  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="3.895" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.458">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.04">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.03">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.048">
   </testsuite>
-  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="21.458" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.463">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.039">
+  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="21.519" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.509">
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.044">
   </testsuite>
-  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="8.483" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="8.396" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.987">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.097">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.207">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="1.019">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.046">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.067">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.03">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.068">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.185">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.024">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.109">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="1.732">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.044">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.036">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.052">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.064">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.024">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="1.285">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.032">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.044">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.025">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.061">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.021">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.066">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionAllAttributes" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.022">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.02">
   </testsuite>
-  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="5.879" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="5.338" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.11">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.026">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.062">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.014">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInEJB" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.06">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.018">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.074">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.052">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.085">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.067">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.466">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.074">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.073">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.528">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.067">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.081">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.031">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.087">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.085">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.022">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.085">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.08">
   </testsuite>
-  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="10.723" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.277">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.056">
+  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="11.272" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.134">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.207">
   </testsuite>
-  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="7.538" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="3.309">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.129">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.119">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.222">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.117">
+  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="6.43" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="2.383">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.1">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.082">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.083">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.075">
   </testsuite>
-  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="13.055" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="0.603">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.053">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.05">
+  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="12.959" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="0.508">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.069">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.037">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.037">
   </testsuite>
-  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.556" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.733">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.041">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.071">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.041">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.071">
+  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.409" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.5">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.076">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.041">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.075">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.047">
   </testsuite>
-  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.647" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.53">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.08">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.05">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.089">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.132">
+  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.55" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.427">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.063">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.056">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.067">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.04">
   </testsuite>
-  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="98.497" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.114">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="11.519">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.958">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="14.996">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.057">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.827">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.015">
+  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="99.598" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.075">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="14.064">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.024">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.969">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.998">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.056">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.076">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.835">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.013">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFuture" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.02">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionDefaults" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.896">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.025">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionDefaults" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.907">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.02">
   </testsuite>
-  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="98.976" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.089">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.221">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.981">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="13.996">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFuture" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.032">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.906">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.017">
+  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="98.983" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.048">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="14.387">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.977">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="12.999">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.024">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFuture" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.025">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.922">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.016">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.018">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.881">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFutureEJB" time="0.019">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.9">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFutureEJB" time="0.015">
   </testsuite>
-  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.347" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.454" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityFullTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.895" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.393" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityWebTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="4.951" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="1.449">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.015">
+  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="4.812" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="1.459">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.027">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.031">
   </testsuite>
-  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.742" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.606">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.048">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="1.061">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSubmit" time="3.042">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.036">
+  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.447" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.539">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.071">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.053">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="1.076">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.037">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSubmit" time="3.041">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.033">
   </testsuite>
-  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.357" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.504">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.06">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSchedule" time="4.046">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.036">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.037">
+  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="46.807" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.512">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.054">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSchedule" time="4.048">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.074">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.044">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.04">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.041">
   </testsuite>
-  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.469" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.545">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="0.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.049">
+  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.549" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.462">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.037">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.037">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="0.038">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.031">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.034">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.029">
   </testsuite>
-  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.479" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.479">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.061">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.038">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.068">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.038">
+  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="3.922" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.386">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.047">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.056">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.041">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.057">
   </testsuite>
-  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.385" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.453">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.07">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.044">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.072">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.038">
+  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="3.473" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.436">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.042">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.06">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.093">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.037">
   </testsuite>
-  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="105.312" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.054">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="12.872">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.974">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="0.676">
+  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="103.062" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.093">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.029">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.093">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="11.384">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.987">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.011">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="0.188">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="12.305">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSE" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.17">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.025">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.757">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.025">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="5.958">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="4.68">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.789">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSE" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.185">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.042">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.029">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.72">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.018">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="5.967">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.693">
   </testsuite>
-  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="104.779" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.049">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodRunsWithContext" time="0.01">
+  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="107.006" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.034">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodRunsWithContext" time="0.013">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodWithMaxAsync3" time="1.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="12.153">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.985">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.619">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.445">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.987">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="0.941">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="14.36">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSE" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.369">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.027">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="13.57">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="5.97">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="1.982">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="13.032">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSE" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.954">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.029">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="12.989">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.025">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.021">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="4.947">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.011">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="5.712">
   </testsuite>
-  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.341" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.396" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityFullTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.022" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.394" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityWebTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.907" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.331">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.019">
+  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.949" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.353">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.046">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.02">
   </testsuite>
-  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.415" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.043">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.015">
+  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.383" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.052">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.017">
   </testsuite>
-  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.434" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.013">
+  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.095" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.025">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.012">
   </testsuite>
-  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.492" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.322" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.111">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.02">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.109">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.016">
   </testsuite>
-  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.328" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.436" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.05">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.021">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.037">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.063">
   </testsuite>
-  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="8.384" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.274">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.022">
+  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="8.276" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.276">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.013">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testRollbackTransactionWithManagedThreadFactory" time="1.011">
   </testsuite>
-  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.74" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.444" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.135">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedContextServiceQualifiers" time="0.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.019">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.111">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.04">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedContextServiceQualifiers" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.012">
   </testsuite>
-  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.615" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.586" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesContextService" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.021">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.045">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesContextService" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.028">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.015">
   </testsuite>
-  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.384" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.069">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.016">
+  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.438" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.053">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.009">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.008">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.009">
   </testsuite>
-  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.401" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.07">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.02">
+  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="6.782" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.092">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.032">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.018">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.035">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.02">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.011">
   </testsuite>
-  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="2.893" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformScheduledExecutor" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformExecutor" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.028">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.057">
+  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="3.489" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformScheduledExecutor" time="0.021">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformExecutor" time="0.022">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="0.04">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.018">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.007">
   </testsuite>
-  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="3.432" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactory" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.014">
+  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="3.376" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.019">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.006">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="0.008">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactory" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.008">
   </testsuite>
-  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="13.201" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="5.175">
+  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="14.901" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="5.5">
   </testsuite>
 </testsuites>
 ----

--- a/jakartaee/11/concurrency/24.0.0.6-beta-Java21-TCKResults.adoc
+++ b/jakartaee/11/concurrency/24.0.0.6-beta-Java21-TCKResults.adoc
@@ -1,21 +1,21 @@
 :page-layout: certification 
 = TCK Results
 
-As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta EE Concurrency.
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta Concurrency.
 
-== Open Liberty 24.0.0.6-beta - Jakarta EE Concurrency Certification Summary (Java 21)
+== Open Liberty 24.0.0.6-beta - Jakarta Concurrency Certification Summary (Java 21)
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-04-23_2000/openliberty-24.0.0.6-beta-cl240520240423-2000.zip[Open Liberty 24.0.0.6-beta]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-05-06_1951/openliberty-24.0.0.6-beta.zip[Open Liberty 24.0.0.6-beta]
 
 * Specification Name, Version and download URL:
 +
-https://jakarta.ee/specifications/concurrency/3.1[Jakarta EE Concurrency 3.1]
+https://jakarta.ee/specifications/concurrency/3.1[Jakarta Concurrency 3.1]
 
 * TCK Version, digital SHA-256 fingerprint and download URL:
 +
-https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.zip[Jakarta EE Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/staged/eftl/concurrency-tck-3.1.0.info[SHA-256]: `7b79bba4167530eb899fecb225e597346c3957f37b3b05bd825d7ab1d58512bd`
+https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.zip[Jakarta Concurrency 3.1 TCK], https://download.eclipse.org/ee4j/cu/jakartaee11/promoted/eftl/concurrency-tck-3.1.0.info[SHA-256]: `a519066b945b6a10ca1a634c9158c038c2e6f52db6c96e988e977740e1fedc56`
 
 * Public URL of TCK Results Summary:
 +
@@ -34,7 +34,7 @@ JCL      - 78c4500a434 based on jdk-21.0.2+13)
 
 * Summary of the information for the certification environment, operating system, cloud, ...:
 +
-Ubuntu (5.4.0-176-generic)
+Ubuntu (5.15.0-107-generic)
 
 Test results:
 
@@ -46,388 +46,388 @@ Test results:
 ----
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="61.369" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="2.973">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.144">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.153">
-      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringThrowableTest" time="0.157">
+  <testsuite errors="0" failures="0" id="0" name="AbortedExceptionTests" package="ee.jakarta.tck.concurrent.api.AbortedException" skipped="0" tests="4" time="52.563" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionNoArgTest" time="2.272">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionThrowableTest" time="0.219">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringTest" time="0.134">
+      <testcase classname="ee.jakarta.tck.concurrent.api.AbortedException.AbortedExceptionTests" name="abortedExceptionStringThrowableTest" time="0.17">
   </testsuite>
-  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="18.14" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.324">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.234">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.163">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.178">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.142">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.176">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.2">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.201">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.222">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.166">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.2">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.195">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.184">
+  <testsuite errors="0" failures="0" id="1" name="ContextServiceTests" package="ee.jakarta.tck.concurrent.api.ContextService" skipped="0" tests="14" time="15.816" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndIntfNoImplemented" time="1.287">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfs" time="0.191">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntf" time="0.131">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionPropertiesNoProxy" time="0.131">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndPropertiesAndIntfNoImplemented" time="0.154">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndProperties" time="0.244">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndIntfNoImplemented" time="0.14">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfsAndPropertiesAndInstanceIsNull" time="0.172">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndIntfNoImplemented" time="0.129">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndInstanceIsNull" time="0.115">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndInstanceIsNull" time="0.15">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithIntfAndProperties" time="0.134">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="contextServiceWithMultiIntfsAndPropertiesAndInstanceIsNull" time="0.153">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ContextService.ContextServiceTests" name="getExecutionProperties" time="0.145">
   </testsuite>
-  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="23.446" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="2.227">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.097">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="2.075">
-      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.156">
+  <testsuite errors="0" failures="0" id="2" name="LastExecutionTests" package="ee.jakarta.tck.concurrent.api.LastExecution" skipped="0" tests="4" time="21.498" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetIdentityNameTest" time="1.916">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultCallableTest" time="2.087">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetResultRunnableTest" time="2.113">
+      <testcase classname="ee.jakarta.tck.concurrent.api.LastExecution.LastExecutionTests" name="lastExecutionGetRunningTimeTest" time="4.1">
   </testsuite>
-  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="10.99" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="1.099">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.114">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithMapAndNullArg" time="0.109">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.124">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.142">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.139">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.15">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.106">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.199">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.168">
+  <testsuite errors="0" failures="0" id="3" name="ManagedExecutorsTests" package="ee.jakarta.tck.concurrent.api.ManagedExecutors" skipped="0" tests="10" time="10.315" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithNullArg" time="0.856">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdownManageableThread" time="0.118">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithMapAndNullArg" time="0.094">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListenerAndMap" time="0.114">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithNullArg" time="0.159">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageRunnableTaskWithTaskListener" time="0.133">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithMapAndNullArg" time="0.102">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="isCurrentThreadShutdown" time="0.091">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListenerAndMap" time="0.111">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedExecutors.ManagedExecutorsTests" name="manageCallableTaskWithTaskListener" time="0.095">
   </testsuite>
-  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="7.429" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="1.204">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.173">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.12">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.163">
+  <testsuite errors="0" failures="0" id="4" name="ManagedScheduledExecutorServiceTests" package="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService" skipped="0" tests="4" time="5.89" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess1Test" time="0.864">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="normalScheduleProcess2Test" time="0.063">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCallableScheduleProcessTest" time="0.08">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedScheduledExecutorService.ManagedScheduledExecutorServiceTests" name="nullCommandScheduleProcessTest" time="0.089">
   </testsuite>
-  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="7.263" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="1.119">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.096">
+  <testsuite errors="0" failures="0" id="5" name="ManagedTaskTests" package="ee.jakarta.tck.concurrent.api.ManagedTask" skipped="0" tests="2" time="5.458" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getManagedTaskListener" time="0.685">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTask.ManagedTaskTests" name="getExecutionProperties" time="0.041">
   </testsuite>
-  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="13.941" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="1.102">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.171">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="1.107">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="2.083">
+  <testsuite errors="0" failures="0" id="6" name="ManagedTaskListenerTests" package="ee.jakarta.tck.concurrent.api.ManagedTaskListener" skipped="0" tests="4" time="10.937" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskSubmitted" time="0.687">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskDone" time="4.064">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskStarting" time="0.071">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedTaskListener.ManagedTaskListenerTests" name="taskAborted" time="1.08">
   </testsuite>
-  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="6.827" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="0.915">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.058">
-      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.108">
+  <testsuite errors="0" failures="0" id="7" name="ManagedThreadFactoryTests" package="ee.jakarta.tck.concurrent.api.ManagedThreadFactory" skipped="0" tests="3" time="5.37" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="isShutdown" time="0.482">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="implementsManageableThreadInterfaceTest" time="0.05">
+      <testcase classname="ee.jakarta.tck.concurrent.api.ManagedThreadFactory.ManagedThreadFactoryTests" name="interruptThreadApiTest" time="1.065">
   </testsuite>
-  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="5.558" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.699">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.07">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.093">
-      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.054">
+  <testsuite errors="0" failures="0" id="8" name="SkippedExceptionTests" package="ee.jakarta.tck.concurrent.api.SkippedException" skipped="0" tests="4" time="4.398" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionThrowableTest" time="0.491">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionNoArgTest" time="0.047">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringThrowableTest" time="0.036">
+      <testcase classname="ee.jakarta.tck.concurrent.api.SkippedException.SkippedExceptionTests" name="skippedExceptionStringTest" time="0.036">
   </testsuite>
-  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="23.434" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.674">
-      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.056">
+  <testsuite errors="0" failures="0" id="9" name="TriggerTests" package="ee.jakarta.tck.concurrent.api.Trigger" skipped="0" tests="2" time="21.564" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerGetNextRunTimeTest" time="16.902">
+      <testcase classname="ee.jakarta.tck.concurrent.api.Trigger.TriggerTests" name="triggerSkipRunTest" time="1.036">
   </testsuite>
-  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="9.944" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="10" name="ContextPropagationFullTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="3" tests="18" time="7.979" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.937">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.05">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.19">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.033">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.759">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualConsumer" time="0.043">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInEJB" time="0.125">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.058">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.088">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.207">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testJNDIContextAndCreateProxyInServlet" time="0.075">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityAndCreateProxyInServlet" time="0.151">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="2.405">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.039">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.05">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.141">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.11">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.03">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.079">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionAllAttributes" time="0.084">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.082">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testSecurityPropagatedContext" time="1.516">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowSubscriber" time="0.032">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionDefaults" time="0.047">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testCopyWithContextCapture" time="0.03">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualSupplier" time="0.056">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.02">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testClassloaderAndCreateProxyInServlet" time="0.069">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextServiceDefinitionAllAttributes" time="0.024">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationFullTests" name="testContextualFlowProcessor" time="0.074">
   </testsuite>
-  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="6.403" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="11" name="ContextPropagationWebTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate" skipped="4" tests="18" time="4.965" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityUnchangedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.085">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.068">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBAllAttributes" time="0.086">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualConsumer" time="0.055">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInEJB" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.034">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionWithThirdPartyContext" time="0.022">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityClearedContext" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.093">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.081">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testJNDIContextAndCreateProxyInServlet" time="0.038">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityAndCreateProxyInServlet" time="0.077">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFunction" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.715">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.063">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.081">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.025">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.097">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.076">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.071">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.028">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.068">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testSecurityPropagatedContext" time="0.515">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowSubscriber" time="0.023">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionDefaults" time="0.02">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testCopyWithContextCapture" time="0.019">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualSupplier" time="0.084">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionFromEJBDefaults" time="0.084">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testClassloaderAndCreateProxyInServlet" time="0.022">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextServiceDefinitionAllAttributes" time="0.069">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextPropagationWebTests" name="testContextualFlowProcessor" time="0.026">
   </testsuite>
-  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="13.206" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.184">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.066">
+  <testsuite errors="0" failures="0" id="12" name="ContextPropagationServletTests" package="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet" skipped="0" tests="2" time="10.763" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testClassloaderInServlet" time="0.223">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.servlet.ContextPropagationServletTests" name="testJNDIContextInServlet" time="0.044">
   </testsuite>
-  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="6.978" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="2.583">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.132">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.111">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.115">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.14">
+  <testsuite errors="0" failures="0" id="13" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ContextService.tx" skipped="0" tests="5" time="7.058" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndCommit" time="2.636">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndRollback" time="0.144">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testSuspendAndCommit" time="0.096">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testDefaultAndCommit" time="0.098">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ContextService.tx.TransactionTests" name="testTransactionOfExecuteThreadAndRollback" time="0.319">
   </testsuite>
-  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="14.105" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="1.232">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.088">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.062">
+  <testsuite errors="0" failures="0" id="14" name="InheritedAPITests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi" skipped="0" tests="4" time="13.396" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testExecute" time="0.573">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAll" time="3.079">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testInvokeAny" time="3.044">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.inheritedapi.InheritedAPITests" name="testSubmit" time="3.045">
   </testsuite>
-  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="5.425" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.678">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.054">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.08">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.085">
+  <testsuite errors="0" failures="0" id="15" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.464" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.567">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.035">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.072">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.071">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.041">
   </testsuite>
-  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="5.5" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.75">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.057">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.085">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.077">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.075">
+  <testsuite errors="0" failures="0" id="16" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.313" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.528">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.031">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.075">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.063">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.045">
   </testsuite>
-  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="100.496" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.137">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="14.636">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.965">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.998">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.085">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.02">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.038">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.783">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFuture" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.017">
+  <testsuite errors="0" failures="0" id="17" name="ManagedExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="96.577" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.065">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="10.3">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsyncCompletionStage" time="0.025">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.975">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="14.999">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFutureEJB" time="0.061">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFuture" time="0.064">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodVoidReturnType" time="0.016">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.094">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="14.758">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.025">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testIncompleteFuture" time="0.026">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.024">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionDefaults" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.879">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.021">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionAllAttributes" time="1.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testManagedExecutorDefinitionDefaults" time="0.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.016">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.863">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionFullTests" name="testCopyCompletableFutureEJB" time="0.025">
   </testsuite>
-  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="99.09" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.078">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.878">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.026">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.97">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="12.997">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.024">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFuture" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.042">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.872">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.022">
+  <testsuite errors="0" failures="0" id="18" name="ManagedExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef" skipped="1" tests="19" time="99.079" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.057">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.39">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsyncCompletionStage" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.98">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="13.998">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFutureEJB" time="0.027">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFuture" time="0.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodVoidReturnType" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.036">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.901">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletableFuture" time="1.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testIncompleteFuture" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testAsynchronousMethodReturnsCompletionStage" time="1.014">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCompletedFuture" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.878">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionAllAttributes" time="1.018">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testManagedExecutorDefinitionDefaults" time="0.022">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.022">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.88">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.ManagedExecutorDefinitionWebTests" name="testCopyCompletableFutureEJB" time="0.019">
   </testsuite>
-  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.39" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="19" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.314" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityFullTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.453" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="20" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security" skipped="1" tests="1" time="3.463" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.security.SecurityWebTests" name="managedExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="5.39" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="1.543">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.03">
+  <testsuite errors="0" failures="0" id="21" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx" skipped="0" tests="3" time="5.901" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedExecutorService" time="2.637">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedExecutorService" time="0.027">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedExecutorService" time="0.037">
   </testsuite>
-  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.528" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.613">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="1.067">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.041">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSubmit" time="3.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.04">
+  <testsuite errors="0" failures="0" id="22" name="InheritedAPIFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.297" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAll" time="3.527">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiInvokeAny" time="3.054">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSchedule" time="4.043">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiExecute" time="0.066">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleWithFixedDelay" time="15.052">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiSubmit" time="3.047">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIFullTests" name="testApiScheduleAtFixedRate" time="15.061">
   </testsuite>
-  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="47.027" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.554">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.045">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSchedule" time="4.051">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.051">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.042">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.037">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.037">
+  <testsuite errors="0" failures="0" id="23" name="InheritedAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="46.921" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAll" time="3.584">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiInvokeAny" time="3.055">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSchedule" time="4.057">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiExecute" time="0.071">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleWithFixedDelay" time="15.065">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiSubmit" time="3.048">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIServletTests" name="testApiScheduleAtFixedRate" time="15.05">
   </testsuite>
-  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="48.049" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.545">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.047">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="0.061">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.053">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.035">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.046">
+  <testsuite errors="0" failures="0" id="24" name="InheritedAPIWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi" skipped="0" tests="7" time="46.941" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAll" time="3.484">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiInvokeAny" time="3.045">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSchedule" time="4.039">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiExecute" time="0.051">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleWithFixedDelay" time="15.049">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiSubmit" time="3.039">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPIWebTests" name="testApiScheduleAtFixedRate" time="15.04">
   </testsuite>
-  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.384" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.6">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.06">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.069">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.067">
+  <testsuite errors="0" failures="0" id="25" name="ForbiddenAPIEJBTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="3.913" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsShutdown" time="0.368">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testAwaitTermination" time="0.049">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdown" time="0.079">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testShutdownNow" time="0.048">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIEJBTests" name="testIsTerminated" time="0.064">
   </testsuite>
-  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="4.394" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.569">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.086">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.052">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.08">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.089">
+  <testsuite errors="0" failures="0" id="26" name="ForbiddenAPIServletTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi" skipped="0" tests="5" time="3.429" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsShutdown" time="0.387">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testAwaitTermination" time="0.061">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdown" time="0.034">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testShutdownNow" time="0.056">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.managed.forbiddenapi.ForbiddenAPIServletTests" name="testIsTerminated" time="0.033">
   </testsuite>
-  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="105.09" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.057">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.074">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="13.519">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.032">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.959">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.088">
+  <testsuite errors="0" failures="0" id="27" name="ManagedScheduledExecutorDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="103.722" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedFuture" time="10.045">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodRunsWithContext" time="0.016">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsynchronousMethodWithMaxAsync3" time="1.028">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.049">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedResult" time="11.363">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSEEJB" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchCompletedExceptionally" time="9.982">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testNotAnAsynchronousMethod" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.276">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.894">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchOverlapSkipping" time="13.708">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testIncompleteFutureMSE" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.089">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.035">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.06">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.792">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="5.922">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="1.985">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.268">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithZonedTrigger" time="0.022">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchVoidReturn" time="27.024">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithMultipleSchedules" time="13.661">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testAsyncCompletionStageMSE" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduleWithCronTrigger" time="5.974">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionFullTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.775">
   </testsuite>
-  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="105.084" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.048">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodRunsWithContext" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodWithMaxAsync3" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.022">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="13.497">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.013">
+  <testsuite errors="0" failures="0" id="28" name="ManagedScheduledExecutorDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef" skipped="1" tests="21" time="106.267" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedFuture" time="10.046">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodRunsWithContext" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsynchronousMethodWithMaxAsync3" time="1.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributesEJB" time="1.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedResult" time="12.678">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSEEJB" time="0.01">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchCompletedExceptionally" time="9.986">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.01">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="1.101">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testNotAnAsynchronousMethod" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaultsEJB" time="0.533">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testCompletedFutureMSE" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="13.885">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSE" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="1.09">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="13.833">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="4.97">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="2.988">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchOverlapSkipping" time="14.45">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testIncompleteFutureMSE" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionDefaults" time="0.534">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithZonedTrigger" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchVoidReturn" time="27.026">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithMultipleSchedules" time="14.405">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchWithInvalidJNDIName" time="0.011">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testAsyncCompletionStageMSE" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduleWithCronTrigger" time="4.978">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testManagedScheduledExecutorDefinitionAllAttributes" time="1.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionWebTests" name="testScheduledAsynchIgnoresMaxAsync" time="5.037">
   </testsuite>
-  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.386" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="29" name="SecurityFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.329" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityFullTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="3.341" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="30" name="SecurityWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security" skipped="1" tests="1" time="2.946" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.security.SecurityWebTests" name="managedScheduledExecutorServiceAPISecurityTest" time="0.0">
   </testsuite>
-  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.92" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.425">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.024">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.014">
+  <testsuite errors="0" failures="0" id="31" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx" skipped="0" tests="3" time="4.373" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testRollbackTransactionWithManagedScheduledExecutorService" time="0.548">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCancelTransactionWithManagedScheduledExecutorService" time="1.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.tx.TransactionTests" name="testCommitTransactionWithManagedScheduledExecutorService" time="0.015">
   </testsuite>
-  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.417" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.031">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.016">
+  <testsuite errors="0" failures="0" id="32" name="ContextFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="3.906" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationTest" time="0.055">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextFullTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.012">
   </testsuite>
-  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="4.388" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.034">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.013">
+  <testsuite errors="0" failures="0" id="33" name="ContextWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context" skipped="0" tests="2" time="3.936" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationTest" time="0.029">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.context.ContextWebTests" name="jndiClassloaderPropagationWithSecurityTest" time="1.01">
   </testsuite>
-  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.416" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="34" name="ManagedThreadFactoryDefinitionFullTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.43" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.122">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.064">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.061">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionFullTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.068">
   </testsuite>
-  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="4.077" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="35" name="ManagedThreadFactoryDefinitionWebTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef" skipped="4" tests="6" time="3.396" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributesEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionAllAttributes" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactoryEJB" time="0.0">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testParallelStreamBackedByManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.054">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaultsEJB" time="0.028">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionWebTests" name="testManagedThreadFactoryDefinitionDefaults" time="0.032">
   </testsuite>
-  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="7.916" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.427">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.018">
+  <testsuite errors="0" failures="0" id="36" name="TransactionTests" package="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx" skipped="0" tests="3" time="7.327" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCommitTransactionWithManagedThreadFactory" time="1.339">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testCancelTransactionWithManagedThreadFactory" time="2.015">
       <testcase classname="ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.tx.TransactionTests" name="testRollbackTransactionWithManagedThreadFactory" time="1.009">
   </testsuite>
-  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.514" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="37" name="AnnotationFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.038" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.16">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.101">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.011">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedManagedThreadFactoryQualifersFull" time="0.016">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesContextService" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedExecutor" time="1.016">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnoDefinedContextServiceQualifiers" time="0.011">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.028">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationFullTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.013">
   </testsuite>
-  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.475" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+  <testsuite errors="0" failures="0" id="38" name="AnnotationWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.anno" skipped="1" tests="8" time="5.385" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.051">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.032">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesContextService" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.04">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.018">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.016">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedScheduledExecutorSvcQualifers" time="0.049">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedExecutorSvcQualifiers" time="0.036">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesContextService" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedManagedThreadFactoryQualifersWeb" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedExecutor" time="1.011">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnoDefinedContextServiceQualifiers" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.anno.AnnotationWebTests" name="testAnnotationDefinesManagedScheduledExecutor" time="1.017">
   </testsuite>
-  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.608" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.056">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.025">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.013">
+  <testsuite errors="0" failures="0" id="39" name="DeploymentDescriptorFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.451" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.085">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.014">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.01">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.012">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.021">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.011">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.007">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorFullTests" name="testDeploymentDescriptorDefinesContextService" time="0.008">
   </testsuite>
-  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.846" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.053">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.029">
+  <testsuite errors="0" failures="0" id="40" name="DeploymentDescriptorWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.dd" skipped="1" tests="8" time="5.354" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedScheduledExecutor" time="1.048">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedContextServiceQualifiers" time="0.015">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedExecutor" time="1.014">
       <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesManagedThreadFactory" time="0.0">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.023">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.04">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedExecutorSvcQualifiers" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedScheduledExecutorSvcQualifers" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinedManagedThreadFactoryQualifers" time="0.009">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorWebTests" name="testDeploymentDescriptorDefinesContextService" time="0.007">
   </testsuite>
-  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="7.406" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformScheduledExecutor" time="0.029">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformExecutor" time="0.014">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="4.126">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.022">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.019">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.055">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.02">
+  <testsuite errors="0" failures="0" id="41" name="VirtualFullTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="7.689" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformScheduledExecutor" time="0.02">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformExecutor" time="0.012">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualScheduledExecutor" time="4.075">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactory" time="0.01">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualThreadFactoryForkJoinPool" time="0.013">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testPlatformThreadFactory" time="0.008">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualFullTests" name="testVirtualExecutor" time="0.01">
   </testsuite>
-  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="7.438" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.022">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.013">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="4.033">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactory" time="0.015">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.017">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.009">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.016">
+  <testsuite errors="0" failures="0" id="42" name="VirtualWebTests" package="ee.jakarta.tck.concurrent.spec.Platform.virtual" skipped="0" tests="7" time="6.911" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformScheduledExecutor" time="0.017">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformExecutor" time="0.011">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualScheduledExecutor" time="4.024">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactory" time="0.008">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualThreadFactoryForkJoinPool" time="0.008">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testPlatformThreadFactory" time="0.006">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.Platform.virtual.VirtualWebTests" name="testVirtualExecutor" time="0.01">
   </testsuite>
-  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="16.955" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
-      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="7.405">
+  <testsuite errors="0" failures="0" id="43" name="SignatureTests" package="ee.jakarta.tck.concurrent.spec.signature" skipped="0" tests="1" time="13.487" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.concurrent.spec.signature.SignatureTests" name="testSignatures" time="5.761">
   </testsuite>
 </testsuites>
 ----

--- a/jakartaee/11/data/24.0.0.6-beta-Java17-TCKResults.adoc
+++ b/jakartaee/11/data/24.0.0.6-beta-Java17-TCKResults.adoc
@@ -1,0 +1,163 @@
+:page-layout: certification 
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta Data.
+
+== Open Liberty 24.0.0.6-beta - Jakarta Data Certification Summary (Java 17)
+
+* Product Name, Version and download URL (if applicable):
++
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-05-06_1951/openliberty-24.0.0.6-beta.zip[Open Liberty 24.0.0.6-beta]
+
+* Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/data/1.0[Jakarta Data 1.0]
+
+* TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/ee4j/data/jakartaee11/staged/eftl/data-tck-1.0.0.zip[Jakarta Data 1.0 TCK], https://download.eclipse.org/ee4j/data/jakartaee11/staged/eftl/data-tck-1.0.0.info[SHA-256]: `02dda1984b67f57bf6996942bea6b1234476e7d1a14bd5770f54f1264decaf35`
+
+* Public URL of TCK Results Summary:
++
+link:24.0.0.6-beta-Java17-TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+----
+java version "17.0.4.1" 2022-08-12
+IBM Semeru Runtime Certified Edition 17.0.4.1 (build 17.0.4.1+1)
+Eclipse OpenJ9 VM 17.0.4.1 (build openj9-0.33.1, JRE 17 Linux amd64-64-Bit Compressed References 20220812_206 (JIT enabled, AOT enabled)
+OpenJ9   - 1d9d16830
+OMR      - b58aa2708
+JCL      - df9b7169bff based on jdk-17.0.4.1+1)
+----
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Ubuntu (5.15.0-107-generic)
+
+Test results:
+
+----
+[INFO] Tests run: 99, Failures: 0, Errors: 0, Skipped: 0
+----
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" id="0" name="CDITests(full)" package="ee.jakarta.tck.data.core.cdi" skipped="0" tests="2" time="58.288" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.core.cdi.CDITests(full)" name="testDataRepositoryHonorsProviderAttribute" time="2.429">
+      <testcase classname="ee.jakarta.tck.data.core.cdi.CDITests(full)" name="testDataRepositoryHonorsEntityDefiningAnnotation" time="0.183">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="1" name="EntityTests(full)" package="ee.jakarta.tck.data.standalone.entity" skipped="0" tests="73" time="32.441" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageOfNothing" time="1.738">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testThirdAndFourthSlicesOf5" time="0.743">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageOf7FromCursor" time="0.473">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testContainsInString" time="0.417">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testSingleEntity" time="0.485">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstSliceOf5" time="0.433">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithOr" time="0.312">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAttributeNames" time="0.502">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testEmptyQuery" time="0.406">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testOrderByHasPrecedenceOverPageRequestSorts" time="0.578">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testDefaultMethod" time="0.421">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testEmptyResultException" time="0.425">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithNull" time="0.429">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testNot" time="0.337">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStreamsFromList" time="0.276">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelDescendingSortsPreGenerated" time="0.321">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralInteger" time="0.283">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testVarargsSort" time="0.239">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAscendingSortsPreGenerated" time="0.247">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindOne" time="0.28">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFalse" time="0.25">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLimit" time="0.265">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testTrue" time="0.26">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBasicRepository" time="0.286">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLessThanWithCount" time="0.328">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindFirst3" time="0.241">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testNonUniqueResultException" time="0.27">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFinalSliceOfUpTo5" time="0.274">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBy" time="0.27">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testIn" time="0.279">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testOr" time="0.271">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralEnumAndLiteralFalse" time="0.253">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLimitToOneResult" time="0.249">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithNot" time="0.312">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testThirdAndFourthPagesOf10" time="0.3">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testSliceOfNothing" time="0.261">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithParenthesis" time="0.245">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLimitedRange" time="0.321">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindList" time="0.243">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindPage" time="0.34">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPageOfNothing" time="0.281">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testIgnoreCase" time="0.3">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstPageOf10" time="0.299">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBasicRepositoryBuiltInMethods" time="0.224">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindAllWithPagination" time="0.247">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCommonInterfaceQueries" time="0.228">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testDataRepository" time="0.219">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPrimaryEntityClassDeterminedByLifeCycleMethods" time="0.286">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstCursoredPageOf8AndNextPages" time="0.263">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelDescendingSorts" time="0.247">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testUpdateQueryWithoutWhereClause" time="0.223">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testDescendingSort" time="0.23">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBasicRepositoryMethods" time="0.396">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testGreaterThanEqualExists" time="0.28">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="ensureCharacterPrepopulation" time="0.228">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBeyondFinalSlice" time="0.267">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAttributeNamesPreGenerated" time="0.232">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindFirst" time="0.251">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralTrue" time="0.243">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindOptional" time="0.254">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFinalPageOfUpTo10" time="0.214">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageWithoutTotalOfNothing" time="0.219">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstCursoredPageWithoutTotalOf6AndNextPages" time="0.236">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testOrderByHasPrecedenceOverSorts" time="0.288">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPartialQueryOrderBy" time="0.284">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralString" time="0.303">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="ensureNaturalNumberPrepopulation" time="0.242">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testUpdateQueryWithWhereClause" time="0.221">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testMixedSort" time="0.23">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPartialQuerySelectAndOrderBy" time="0.223">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAscendingSorts" time="0.22">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageWithoutTotalOf9FromCursor" time="0.211">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBeyondFinalPage" time="0.258">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="2" name="PersistenceEntityTests(full)" package="ee.jakarta.tck.data.standalone.persistence" skipped="0" tests="10" time="11.909" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testLike" time="2.326">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testNull" time="0.496">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testMultipleInsertUpdateDelete" time="0.67">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testInsertEntityThatAlreadyExists" time="0.516">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testIdAttributeWithDifferentName" time="0.571">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testVersionedInsertUpdateDelete" time="0.535">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testQueryWithNamedParameters" time="0.454">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testEntityManager" time="0.239">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testQueryWithPositionalParameters" time="0.556">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testNotRunOnNOSQL" time="0.335">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="3" name="SignatureTests(full)" package="ee.jakarta.tck.data.standalone.signature" skipped="0" tests="1" time="22.944" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.standalone.signature.SignatureTests(full)" name="testSignatures" time="10.864">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="4" name="ComplexServletTests(full)" package="ee.jakarta.tck.data.web.example" skipped="0" tests="3" time="3.877" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.web.example.ComplexServletTests(full)" name="testSuccessAndFailure(TestInfo)" time="0.067">
+      <testcase classname="ee.jakarta.tck.data.web.example.ComplexServletTests(full)" name="testServletSideCustomResponse(TestInfo)" time="0.021">
+      <testcase classname="ee.jakarta.tck.data.web.example.ComplexServletTests(full)" name="testMatchServletSideMethodName(TestInfo)" time="0.012">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="5" name="PersistenceTests(full)" package="ee.jakarta.tck.data.web.transaction" skipped="0" tests="2" time="5.433" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.web.transaction.PersistenceTests(full)" name="testRollback" time="1.796">
+      <testcase classname="ee.jakarta.tck.data.web.transaction.PersistenceTests(full)" name="testCommit" time="0.149">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="6" name="ValidationTests(full)" package="ee.jakarta.tck.data.web.validation" skipped="0" tests="8" time="5.99" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateWithInvalidConstraints" time="1.1">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateWithValidConstraints" time="0.192">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateAllWithValidConstraints" time="0.487">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateAllWithInvalidConstraints" time="0.216">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testValidResultsFromMethod" time="0.216">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testSaveWithValidConstraints" time="0.258">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testSaveWithInvalidConstraints" time="0.124">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testInvalidResultsFromMethod" time="0.202">
+  </testsuite>
+</testsuites>
+----

--- a/jakartaee/11/data/24.0.0.6-beta-Java21-TCKResults.adoc
+++ b/jakartaee/11/data/24.0.0.6-beta-Java21-TCKResults.adoc
@@ -1,0 +1,163 @@
+:page-layout: certification 
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta Data.
+
+== Open Liberty 24.0.0.6-beta - Jakarta Data Certification Summary (Java 21)
+
+* Product Name, Version and download URL (if applicable):
++
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-05-06_1951/openliberty-24.0.0.6-beta.zip[Open Liberty 24.0.0.6-beta]
+
+* Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/data/1.0[Jakarta Data 1.0]
+
+* TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/ee4j/data/jakartaee11/staged/eftl/data-tck-1.0.0.zip[Jakarta Data 1.0 TCK], https://download.eclipse.org/ee4j/data/jakartaee11/staged/eftl/data-tck-1.0.0.info[SHA-256]: `02dda1984b67f57bf6996942bea6b1234476e7d1a14bd5770f54f1264decaf35`
+
+* Public URL of TCK Results Summary:
++
+link:24.0.0.6-beta-Java21-TCKResults.html[TCK results summary]
+
+* Java runtime used to run the implementation:
++
+----
+openjdk version "21.0.2" 2024-01-16 LTS
+IBM Semeru Runtime Open Edition 21.0.2.0 (build 21.0.2+13-LTS)
+Eclipse OpenJ9 VM 21.0.2.0 (build openj9-0.43.0, JRE 21 Linux amd64-64-Bit Compressed References 20240116_94 (JIT enabled, AOT enabled)
+OpenJ9   - 2c3d78b48
+OMR      - ea8124dbc
+JCL      - 78c4500a434 based on jdk-21.0.2+13)
+----
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Ubuntu (5.15.0-107-generic)
+
+Test results:
+
+----
+[INFO] Tests run: 99, Failures: 0, Errors: 0, Skipped: 0
+----
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" id="0" name="CDITests(full)" package="ee.jakarta.tck.data.core.cdi" skipped="0" tests="2" time="58.005" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.core.cdi.CDITests(full)" name="testDataRepositoryHonorsProviderAttribute" time="2.01">
+      <testcase classname="ee.jakarta.tck.data.core.cdi.CDITests(full)" name="testDataRepositoryHonorsEntityDefiningAnnotation" time="0.174">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="1" name="EntityTests(full)" package="ee.jakarta.tck.data.standalone.entity" skipped="0" tests="73" time="28.899" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageOfNothing" time="1.585">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testThirdAndFourthSlicesOf5" time="0.703">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageOf7FromCursor" time="0.604">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testContainsInString" time="0.606">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testSingleEntity" time="0.43">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstSliceOf5" time="0.382">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithOr" time="0.467">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAttributeNames" time="0.403">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testEmptyQuery" time="0.492">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testOrderByHasPrecedenceOverPageRequestSorts" time="0.82">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testDefaultMethod" time="0.503">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testEmptyResultException" time="0.302">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithNull" time="0.271">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testNot" time="0.309">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStreamsFromList" time="0.277">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelDescendingSortsPreGenerated" time="0.21">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralInteger" time="0.266">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testVarargsSort" time="0.24">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAscendingSortsPreGenerated" time="0.249">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindOne" time="0.268">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFalse" time="0.26">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLimit" time="0.256">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testTrue" time="0.27">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBasicRepository" time="0.308">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLessThanWithCount" time="0.279">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindFirst3" time="0.277">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testNonUniqueResultException" time="0.323">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFinalSliceOfUpTo5" time="0.272">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBy" time="0.24">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testIn" time="0.238">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testOr" time="0.283">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralEnumAndLiteralFalse" time="0.216">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLimitToOneResult" time="0.246">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithNot" time="0.281">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testThirdAndFourthPagesOf10" time="0.228">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testSliceOfNothing" time="0.239">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testQueryWithParenthesis" time="0.222">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLimitedRange" time="0.23">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindList" time="0.235">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindPage" time="0.215">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPageOfNothing" time="0.274">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testIgnoreCase" time="0.219">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstPageOf10" time="0.22">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBasicRepositoryBuiltInMethods" time="0.257">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindAllWithPagination" time="0.2">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCommonInterfaceQueries" time="0.201">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testDataRepository" time="0.319">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPrimaryEntityClassDeterminedByLifeCycleMethods" time="0.296">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstCursoredPageOf8AndNextPages" time="0.226">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelDescendingSorts" time="0.216">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testUpdateQueryWithoutWhereClause" time="0.184">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testDescendingSort" time="0.225">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBasicRepositoryMethods" time="0.218">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testGreaterThanEqualExists" time="0.215">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="ensureCharacterPrepopulation" time="0.267">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBeyondFinalSlice" time="0.201">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAttributeNamesPreGenerated" time="0.183">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindFirst" time="0.165">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralTrue" time="0.228">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFindOptional" time="0.157">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFinalPageOfUpTo10" time="0.194">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageWithoutTotalOfNothing" time="0.151">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testFirstCursoredPageWithoutTotalOf6AndNextPages" time="0.095">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testOrderByHasPrecedenceOverSorts" time="0.084">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPartialQueryOrderBy" time="0.104">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testLiteralString" time="0.098">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="ensureNaturalNumberPrepopulation" time="0.111">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testUpdateQueryWithWhereClause" time="0.097">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testMixedSort" time="0.094">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testPartialQuerySelectAndOrderBy" time="0.097">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testStaticMetamodelAscendingSorts" time="0.1">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testCursoredPageWithoutTotalOf9FromCursor" time="0.118">
+      <testcase classname="ee.jakarta.tck.data.standalone.entity.EntityTests(full)" name="testBeyondFinalPage" time="0.163">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="2" name="PersistenceEntityTests(full)" package="ee.jakarta.tck.data.standalone.persistence" skipped="0" tests="10" time="8.864" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testLike" time="1.66">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testNull" time="0.303">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testMultipleInsertUpdateDelete" time="0.43">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testInsertEntityThatAlreadyExists" time="0.272">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testIdAttributeWithDifferentName" time="0.416">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testVersionedInsertUpdateDelete" time="0.4">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testQueryWithNamedParameters" time="0.543">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testEntityManager" time="0.271">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testQueryWithPositionalParameters" time="0.567">
+      <testcase classname="ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests(full)" name="testNotRunOnNOSQL" time="0.3">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="3" name="SignatureTests(full)" package="ee.jakarta.tck.data.standalone.signature" skipped="0" tests="1" time="19.369" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.standalone.signature.SignatureTests(full)" name="testSignatures" time="9.298">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="4" name="ComplexServletTests(full)" package="ee.jakarta.tck.data.web.example" skipped="0" tests="3" time="3.91" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.web.example.ComplexServletTests(full)" name="testSuccessAndFailure(TestInfo)" time="0.111">
+      <testcase classname="ee.jakarta.tck.data.web.example.ComplexServletTests(full)" name="testServletSideCustomResponse(TestInfo)" time="0.017">
+      <testcase classname="ee.jakarta.tck.data.web.example.ComplexServletTests(full)" name="testMatchServletSideMethodName(TestInfo)" time="0.009">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="5" name="PersistenceTests(full)" package="ee.jakarta.tck.data.web.transaction" skipped="0" tests="2" time="4.469" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.web.transaction.PersistenceTests(full)" name="testRollback" time="1.439">
+      <testcase classname="ee.jakarta.tck.data.web.transaction.PersistenceTests(full)" name="testCommit" time="0.16">
+  </testsuite>
+  <testsuite errors="0" failures="0" id="6" name="ValidationTests(full)" package="ee.jakarta.tck.data.web.validation" skipped="0" tests="8" time="5.42" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateWithInvalidConstraints" time="0.902">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateWithValidConstraints" time="0.166">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateAllWithValidConstraints" time="0.464">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testUpdateAllWithInvalidConstraints" time="0.222">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testValidResultsFromMethod" time="0.21">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testSaveWithValidConstraints" time="0.195">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testSaveWithInvalidConstraints" time="0.183">
+      <testcase classname="ee.jakarta.tck.data.web.validation.ValidationTests(full)" name="testInvalidResultsFromMethod" time="0.13">
+  </testsuite>
+</testsuites>
+----


### PR DESCRIPTION
Initial Data 1.0 results + yet another update for Concurrency 3.1