### PR TITLE
MicroProfile 7 - EE 10 Core 24.0.0.9-beta results to staging

### DIFF
--- a/jakartaee/10/coreprofile/24.0.0.9-beta-Java11-TCKResults.adoc
+++ b/jakartaee/10/coreprofile/24.0.0.9-beta-Java11-TCKResults.adoc
@@ -1,0 +1,151 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta EE Core Profile 10.
+
+== Open Liberty 24.0.0.9-beta Jakarta EE Core Profile 10 using Java 11 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-07-09_0302/openliberty-24.0.0.9-beta-cl240820240709-0302.zip[Open Liberty 24.0.0.9-beta]
+
+* Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/coreprofile/10[Jakarta EE Core Profile 10]
+
+* TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.3.zip[Jakarta EE Core Profile TCK 10.0.3],
+SHA-256: `a531a6ffc1eedfced6383a519013d176060b8280189141dcd626c26aad8502ac`
+
+* Public URL of TCK Results Summary:
++
+link:24.0.0.9-beta-Java11-TCKResults.html[TCK results summary]
+
+* Any Additional Specification Certification Requirements:
++
+Jakarta Annotations
+https://download.eclipse.org/jakartaee/annotations/2.1/jakarta-annotations-tck-2.1.1.zip[jakarta-annotations-tck-2.1.1.zip],
+SHA-256: `8c2131d51c75cde4be74382f662519f9fd439f4ce4dd60832ed55b796e5f72f3`
++
+Jakarta Contexts and Dependency Injection
+https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.13-dist.zip[cdi-tck-4.0.13-dist.zip],
+SHA-256: `566c547e1a9c66792eefcc6feafea87ab0c0f2e3f71385bf96865359a685df00`
++
+Jakarta Dependency Injection
+https://download.eclipse.org/jakartaee/dependency-injection/2.0/jakarta.inject-tck-2.0.2-bin.zip[jakarta.inject-tck-2.0.2-bin.zip],
+SHA-256: `23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972`
++
+Jakarta JSON Binding
+https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip[jakarta-jsonb-tck-3.0.0.zip],
+SHA-256: `954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b`
++
+Jakarta JSON Processing
+https://download.eclipse.org/jakartaee/jsonp/2.1/jakarta-jsonp-tck-2.1.1.zip[jakarta-jsonp-tck-2.1.1.zip],
+SHA-256: `949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1`
++
+Jakarta RESTful Web Services
+https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.5.zip[jakarta-restful-ws-tck-3.1.5.zip],
+SHA-256: `93bf5bd22a217fd1950026feaeec6a234c7a67137657d64a13bb56b105b0fb2e`
+
+
+* Java runtime used to run the implementation:
++
+----
+java version "11.0.15" 2022-04-19
+IBM Semeru Runtime Certified Edition 11.0.15.0 (build 11.0.15+10)
+Eclipse OpenJ9 VM 11.0.15.0 (build openj9-0.32.0, JRE 11 Linux amd64-64-Bit Compressed References 20220427_337 (JIT enabled, AOT enabled)
+OpenJ9   - 9a84ec34e
+OMR      - ab24b6666
+JCL      - da9a227f69 based on jdk-11.0.15+10)
+----
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Apache Derby, Linux, Ubuntu 18.04
+
+
+Test results:
+
+----
+
+Stage Name: Jakarta Core Profile TCK
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] 
+[INFO] --- maven-failsafe-plugin:3.0.0:verify (verify) @ core-profile-tck-runner ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 01:46 min
+
+
+Stage Name: Jakarta Annotations TCK
+[javatest.batch] ********************************************************************************
+[javatest.batch] Completed running 1 tests.
+[javatest.batch] Number of Tests Passed      = 1
+[javatest.batch] Number of Tests Failed      = 0
+[javatest.batch] Number of Tests with Errors = 0
+[javatest.batch] ********************************************************************************
+[javatest.batch] PASSED........com/sun/ts/tests/signaturetest/caj/CAJSigTest.java#signatureTest
+[javatest.batch] 
+[javatest.batch] Total time = 18s
+
+
+Stage Name: Jakarta Contexts and Dependency Injection TCK
+[INFO] Tests run: 708, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 812.949 s - in TestSuite
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 708, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/surefire-reports/sigtest/TEST-liberty-cdi-tck-runner-4.0.13.xml: 0 failures in /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/api-signature/cdi-api-jdk11.sig
+
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.39 s - in org.jboss.weld.langmodel.tck.LangModelTckTest
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta Dependency Injection TCK
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.578 s - in weld.SampleBootstrapTCK
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta JSON Binding TCK
+[INFO] Results:
+[INFO] 
+[WARNING] Tests run: 295, Failures: 0, Errors: 0, Skipped: 5
+
+
+Stage Name: Jakarta JSON Processing TCK
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.354 s - in ee.jakarta.tck.jsonp.pluggability.jsonprovidertests.ClientTests
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta RESTful Web Services TCK
+[INFO] Results:
+[INFO] 
+[WARNING] Tests run: 2647, Failures: 0, Errors: 0, Skipped: 132
+[INFO] 
+[INFO] 
+[INFO] --- maven-failsafe-plugin:3.0.0:verify (verify) @ jakarta-restful-ws-tck-runner ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 09:19 min
+
+----

--- a/jakartaee/10/coreprofile/24.0.0.9-beta-Java17-TCKResults.adoc
+++ b/jakartaee/10/coreprofile/24.0.0.9-beta-Java17-TCKResults.adoc
@@ -1,0 +1,151 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta EE Core Profile 10.
+
+== Open Liberty 24.0.0.9-beta Jakarta EE Core Profile 10 using Java 17 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-07-09_0302/openliberty-24.0.0.9-beta-cl240820240709-0302.zip[Open Liberty 24.0.0.9-beta]
+
+* Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/coreprofile/10[Jakarta EE Core Profile 10]
+
+* TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.3.zip[Jakarta EE Core Profile TCK 10.0.3],
+SHA-256: `a531a6ffc1eedfced6383a519013d176060b8280189141dcd626c26aad8502ac`
+
+* Public URL of TCK Results Summary:
++
+link:24.0.0.9-beta-Java17-TCKResults.html[TCK results summary]
+
+* Any Additional Specification Certification Requirements:
++
+Jakarta Annotations
+https://download.eclipse.org/jakartaee/annotations/2.1/jakarta-annotations-tck-2.1.1.zip[jakarta-annotations-tck-2.1.1.zip],
+SHA-256: `8c2131d51c75cde4be74382f662519f9fd439f4ce4dd60832ed55b796e5f72f3`
++
+Jakarta Contexts and Dependency Injection
+https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.13-dist.zip[cdi-tck-4.0.13-dist.zip],
+SHA-256: `566c547e1a9c66792eefcc6feafea87ab0c0f2e3f71385bf96865359a685df00`
++
+Jakarta Dependency Injection
+https://download.eclipse.org/jakartaee/dependency-injection/2.0/jakarta.inject-tck-2.0.2-bin.zip[jakarta.inject-tck-2.0.2-bin.zip],
+SHA-256: `23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972`
++
+Jakarta JSON Binding
+https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip[jakarta-jsonb-tck-3.0.0.zip],
+SHA-256: `954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b`
++
+Jakarta JSON Processing
+https://download.eclipse.org/jakartaee/jsonp/2.1/jakarta-jsonp-tck-2.1.1.zip[jakarta-jsonp-tck-2.1.1.zip],
+SHA-256: `949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1`
++
+Jakarta RESTful Web Services
+https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.5.zip[jakarta-restful-ws-tck-3.1.5.zip],
+SHA-256: `93bf5bd22a217fd1950026feaeec6a234c7a67137657d64a13bb56b105b0fb2e`
+
+
+* Java runtime used to run the implementation:
++
+----
+java version "17.0.4.1" 2022-08-12
+IBM Semeru Runtime Certified Edition 17.0.4.1 (build 17.0.4.1+1)
+Eclipse OpenJ9 VM 17.0.4.1 (build openj9-0.33.1, JRE 17 Linux amd64-64-Bit Compressed References 20220812_206 (JIT enabled, AOT enabled)
+OpenJ9   - 1d9d16830
+OMR      - b58aa2708
+JCL      - df9b7169bff based on jdk-17.0.4.1+1)
+----
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Apache Derby, Linux, Ubuntu 18.04
+
+
+Test results:
+
+----
+
+Stage Name: Jakarta Core Profile TCK
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] 
+[INFO] --- maven-failsafe-plugin:3.0.0:verify (verify) @ core-profile-tck-runner ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 01:40 min
+
+
+Stage Name: Jakarta Annotations TCK
+[javatest.batch] ********************************************************************************
+[javatest.batch] Completed running 1 tests.
+[javatest.batch] Number of Tests Passed      = 1
+[javatest.batch] Number of Tests Failed      = 0
+[javatest.batch] Number of Tests with Errors = 0
+[javatest.batch] ********************************************************************************
+[javatest.batch] PASSED........com/sun/ts/tests/signaturetest/caj/CAJSigTest.java#signatureTest
+[javatest.batch] 
+[javatest.batch] Total time = 17s
+
+
+Stage Name: Jakarta Contexts and Dependency Injection TCK
+[INFO] Tests run: 708, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 844.741 s - in TestSuite
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 708, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/surefire-reports/sigtest/TEST-liberty-cdi-tck-runner-4.0.13.xml: 0 failures in /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/api-signature/cdi-api-jdk11.sig
+
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.885 s - in org.jboss.weld.langmodel.tck.LangModelTckTest
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta Dependency Injection TCK
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.515 s - in weld.SampleBootstrapTCK
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta JSON Binding TCK
+[INFO] Results:
+[INFO] 
+[WARNING] Tests run: 295, Failures: 0, Errors: 0, Skipped: 5
+
+
+Stage Name: Jakarta JSON Processing TCK
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.856 s - in ee.jakarta.tck.jsonp.pluggability.jsonprovidertests.ClientTests
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta RESTful Web Services TCK
+[INFO] Results:
+[INFO] 
+[WARNING] Tests run: 2647, Failures: 0, Errors: 0, Skipped: 132
+[INFO] 
+[INFO] 
+[INFO] --- maven-failsafe-plugin:3.0.0:verify (verify) @ jakarta-restful-ws-tck-runner ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 08:58 min
+
+----

--- a/jakartaee/10/coreprofile/24.0.0.9-beta-Java21-TCKResults.adoc
+++ b/jakartaee/10/coreprofile/24.0.0.9-beta-Java21-TCKResults.adoc
@@ -1,0 +1,151 @@
+:page-layout: certification
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of Jakarta EE Core Profile 10.
+
+== Open Liberty 24.0.0.9-beta Jakarta EE Core Profile 10 using Java 21 Certification Summary
+
+* Product Name, Version and download URL (if applicable):
++
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-07-09_0302/openliberty-24.0.0.9-beta-cl240820240709-0302.zip[Open Liberty 24.0.0.9-beta]
+
+* Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/coreprofile/10[Jakarta EE Core Profile 10]
+
+* TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.3.zip[Jakarta EE Core Profile TCK 10.0.3],
+SHA-256: `a531a6ffc1eedfced6383a519013d176060b8280189141dcd626c26aad8502ac`
+
+* Public URL of TCK Results Summary:
++
+link:24.0.0.9-beta-Java21-TCKResults.html[TCK results summary]
+
+* Any Additional Specification Certification Requirements:
++
+Jakarta Annotations
+https://download.eclipse.org/jakartaee/annotations/2.1/jakarta-annotations-tck-2.1.1.zip[jakarta-annotations-tck-2.1.1.zip],
+SHA-256: `8c2131d51c75cde4be74382f662519f9fd439f4ce4dd60832ed55b796e5f72f3`
++
+Jakarta Contexts and Dependency Injection
+https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.13-dist.zip[cdi-tck-4.0.13-dist.zip],
+SHA-256: `566c547e1a9c66792eefcc6feafea87ab0c0f2e3f71385bf96865359a685df00`
++
+Jakarta Dependency Injection
+https://download.eclipse.org/jakartaee/dependency-injection/2.0/jakarta.inject-tck-2.0.2-bin.zip[jakarta.inject-tck-2.0.2-bin.zip],
+SHA-256: `23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972`
++
+Jakarta JSON Binding
+https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip[jakarta-jsonb-tck-3.0.0.zip],
+SHA-256: `954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b`
++
+Jakarta JSON Processing
+https://download.eclipse.org/jakartaee/jsonp/2.1/jakarta-jsonp-tck-2.1.1.zip[jakarta-jsonp-tck-2.1.1.zip],
+SHA-256: `949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1`
++
+Jakarta RESTful Web Services
+https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.5.zip[jakarta-restful-ws-tck-3.1.5.zip],
+SHA-256: `93bf5bd22a217fd1950026feaeec6a234c7a67137657d64a13bb56b105b0fb2e`
+
+
+* Java runtime used to run the implementation:
++
+----
+openjdk version "21.0.2" 2024-01-16 LTS
+IBM Semeru Runtime Open Edition 21.0.2.0 (build 21.0.2+13-LTS)
+Eclipse OpenJ9 VM 21.0.2.0 (build openj9-0.43.0, JRE 21 Linux amd64-64-Bit Compressed References 20240116_94 (JIT enabled, AOT enabled)
+OpenJ9   - 2c3d78b48
+OMR      - ea8124dbc
+JCL      - 78c4500a434 based on jdk-21.0.2+13)
+----
+
+* Summary of the information for the certification environment, operating system, cloud, ...:
++
+Apache Derby, Linux, Ubuntu 18.04
+
+
+Test results:
+
+----
+
+Stage Name: Jakarta Core Profile TCK
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] 
+[INFO] --- maven-failsafe-plugin:3.0.0:verify (verify) @ core-profile-tck-runner ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 02:00 min
+
+
+Stage Name: Jakarta Annotations TCK
+[javatest.batch] ********************************************************************************
+[javatest.batch] Completed running 1 tests.
+[javatest.batch] Number of Tests Passed      = 1
+[javatest.batch] Number of Tests Failed      = 0
+[javatest.batch] Number of Tests with Errors = 0
+[javatest.batch] ********************************************************************************
+[javatest.batch] PASSED........com/sun/ts/tests/signaturetest/caj/CAJSigTest.java#signatureTest
+[javatest.batch] 
+[javatest.batch] Total time = 22s
+
+
+Stage Name: Jakarta Contexts and Dependency Injection TCK
+[INFO] Tests run: 708, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 846.161 s - in TestSuite
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 708, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/surefire-reports/sigtest/TEST-liberty-cdi-tck-runner-4.0.13.xml: 0 failures in /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/api-signature/cdi-api-jdk11.sig
+
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.054 s - in org.jboss.weld.langmodel.tck.LangModelTckTest
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta Dependency Injection TCK
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.787 s - in weld.SampleBootstrapTCK
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta JSON Binding TCK
+[INFO] Results:
+[INFO] 
+[WARNING] Tests run: 295, Failures: 0, Errors: 0, Skipped: 5
+
+
+Stage Name: Jakarta JSON Processing TCK
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.692 s - in ee.jakarta.tck.jsonp.pluggability.jsonprovidertests.ClientTests
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
+
+
+Stage Name: Jakarta RESTful Web Services TCK
+[INFO] Results:
+[INFO] 
+[WARNING] Tests run: 2647, Failures: 0, Errors: 0, Skipped: 132
+[INFO] 
+[INFO] 
+[INFO] --- maven-failsafe-plugin:3.0.0:verify (verify) @ jakarta-restful-ws-tck-runner ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 09:19 min
+
+----


### PR DESCRIPTION
Three results pages. They look good to me on the draft server.

https://certifications-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/certifications/jakartaee/10/coreprofile/24.0.0.9-beta-Java11-TCKResults.html

https://certifications-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/certifications/jakartaee/10/coreprofile/24.0.0.9-beta-Java17-TCKResults.html

https://certifications-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/certifications/jakartaee/10/coreprofile/24.0.0.9-beta-Java21-TCKResults.html