### PR TITLE
[draft] Fix product URLs on Config 3.1 TCK results

### DIFF
--- a/microprofile/7.0/config/3.1/24.0.0.9-beta-cl240920240801-0303-MicroProfile-Config-3.1-Java17-EE10-FEATURES-MicroProfile-70-TCKResults.adoc
+++ b/microprofile/7.0/config/3.1/24.0.0.9-beta-cl240920240801-0303-MicroProfile-Config-3.1-Java17-EE10-FEATURES-MicroProfile-70-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-08-01_0303/openliberty-24.0.0.9-beta-cl240920240801-0303.zipp[Open Liberty 24.0.0.9-beta-cl240920240801-0303]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-08-01_0303/openliberty-24.0.0.9-beta-cl240920240801-0303.zip[Open Liberty 24.0.0.9-beta-cl240920240801-0303]
 
 * Specification Name, Version and download URL:
 +

--- a/microprofile/7.0/config/3.1/24.0.0.9-beta-cl240920240801-0303-MicroProfile-Config-3.1-Java21-EE10-FEATURES-MicroProfile-70-TCKResults.adoc
+++ b/microprofile/7.0/config/3.1/24.0.0.9-beta-cl240920240801-0303-MicroProfile-Config-3.1-Java21-EE10-FEATURES-MicroProfile-70-TCKResults.adoc
@@ -7,7 +7,7 @@ As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Tech
 
 * Product Name, Version and download URL (if applicable):
 +
-https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/24.0.0.9-beta-cl240920240801-0303/openliberty-24.0.0.9-beta-cl240920240801-0303.zip[Open Liberty 24.0.0.9-beta-cl240920240801-0303]
+https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-08-01_0303/openliberty-24.0.0.9-beta-cl240920240801-0303.zip[Open Liberty 24.0.0.9-beta-cl240920240801-0303]
 
 * Specification Name, Version and download URL:
 +


### PR DESCRIPTION
For MP 7.0 certifications.