### PR TITLE
Updated EE 11 Core TCK Results to prod

### DIFF
--- a/jakartaee/11/coreprofile/24.0.0.11-beta-Java17-TCKResults.adoc
+++ b/jakartaee/11/coreprofile/24.0.0.11-beta-Java17-TCKResults.adoc
@@ -16,7 +16,7 @@ https://jakarta.ee/specifications/coreprofile/11[Jakarta EE Core Profile 11]
 * TCK Version, digital SHA-256 fingerprint and download URL:
 +
 https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/jakarta-core-profile-tck-11.0.0.zip[Jakarta EE Core Profile TCK 11.0 (Staged Release)],
-SHA-256: `cd5d039adcb17a626845ee43c03e4ff11fbdec6738afb251bc3b1778c389e1c2`
+SHA-256: `5722bac4f1af78e93ede95feaa448aa0bc19934d0871415c25dd45ffa8c5d1a5`
 
 * Public URL of TCK Results Summary:
 +
@@ -69,10 +69,10 @@ Test results:
 ----
 
 Stage Name: Jakarta Core Profile TCK
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.88 s -- in ee.jakarta.tck.core.json.ApplicationJsonpIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.876 s -- in ee.jakarta.tck.core.jsonb.JsonbApplicationIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.922 s -- in ee.jakarta.tck.core.rest.context.app.ApplicationContextIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.852 s -- in ee.jakarta.tck.core.rest.jsonb.cdi.CustomJsonbSerializationIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.61 s -- in ee.jakarta.tck.core.json.ApplicationJsonpIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.303 s -- in ee.jakarta.tck.core.jsonb.JsonbApplicationIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.828 s -- in ee.jakarta.tck.core.rest.context.app.ApplicationContextIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.839 s -- in ee.jakarta.tck.core.rest.jsonb.cdi.CustomJsonbSerializationIT
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -83,11 +83,11 @@ Stage Name: Jakarta Core Profile TCK
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time: 01:23 min
+[INFO] Total time: 01:25 min
 
 
 Stage Name: Jakarta Annotations TCK
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.877 s -- in ee.jakarta.tck.annotations.signaturetest.CAJSigTestIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.20 s -- in ee.jakarta.tck.annotations.signaturetest.CAJSigTestIT
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -98,11 +98,11 @@ Stage Name: Jakarta Annotations TCK
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time: 47.367 s
+[INFO] Total time: 50.527 s
 
 
 Stage Name: Jakarta Contexts and Dependency Injection TCK
-[INFO] Tests run: 779, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 907.758 s - in TestSuite
+[INFO] Tests run: 779, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 905.895 s - in TestSuite
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -110,7 +110,7 @@ Stage Name: Jakarta Contexts and Dependency Injection TCK
 [INFO] 
 [INFO] /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/surefire-reports/sigtest/TEST-liberty-cdi-tck-runner-4.1.0.xml: 0 failures in /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/api-signature/cdi-api-jdk17.sig
 
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.448 s -- in org.jboss.weld.langmodel.tck.LangModelTckTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.091 s -- in org.jboss.weld.langmodel.tck.LangModelTckTest
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -118,7 +118,7 @@ Stage Name: Jakarta Contexts and Dependency Injection TCK
 
 
 Stage Name: Jakarta Dependency Injection TCK
-[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.281 s -- in weld.SampleBootstrapTCK
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.264 s -- in weld.SampleBootstrapTCK
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -126,48 +126,48 @@ Stage Name: Jakarta Dependency Injection TCK
 
 
 Stage Name: Jakarta JSON Binding TCK
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.680 s -- in ee.jakarta.tck.json.bind.signaturetest.jsonb.JSONBSigTest
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.719 s -- in ee.jakarta.tck.json.bind.customizedmapping.numberformat.NumberFormatCustomizationTest
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.235 s -- in ee.jakarta.tck.json.bind.customizedmapping.nullhandling.NullHandlingCustomizationTest
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.479 s -- in ee.jakarta.tck.json.bind.customizedmapping.dateformat.DateFormatCustomizationTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.116 s -- in ee.jakarta.tck.json.bind.customizedmapping.visibility.VisibilityCustomizationTest
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.438 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertynames.PropertyNameCustomizationTest
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.167 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.OptionalCreatorParametersTest
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.188 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.InstantiationCustomizationTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.124 s -- in ee.jakarta.tck.json.bind.customizedmapping.adapters.AdaptersCustomizationTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s -- in ee.jakarta.tck.json.bind.customizedmapping.serializers.SerializersCustomizationTest
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.204 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertyorder.PropertyOrderCustomizationTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.086 s -- in ee.jakarta.tck.json.bind.customizedmapping.binarydata.BinaryDataCustomizationTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.455 s -- in ee.jakarta.tck.json.bind.signaturetest.jsonb.JSONBSigTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.656 s -- in ee.jakarta.tck.json.bind.customizedmapping.numberformat.NumberFormatCustomizationTest
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.275 s -- in ee.jakarta.tck.json.bind.customizedmapping.nullhandling.NullHandlingCustomizationTest
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.435 s -- in ee.jakarta.tck.json.bind.customizedmapping.dateformat.DateFormatCustomizationTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.087 s -- in ee.jakarta.tck.json.bind.customizedmapping.visibility.VisibilityCustomizationTest
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.388 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertynames.PropertyNameCustomizationTest
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.155 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.OptionalCreatorParametersTest
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.137 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.InstantiationCustomizationTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.103 s -- in ee.jakarta.tck.json.bind.customizedmapping.adapters.AdaptersCustomizationTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.079 s -- in ee.jakarta.tck.json.bind.customizedmapping.serializers.SerializersCustomizationTest
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.264 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertyorder.PropertyOrderCustomizationTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.108 s -- in ee.jakarta.tck.json.bind.customizedmapping.binarydata.BinaryDataCustomizationTest
 [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.204 s -- in ee.jakarta.tck.json.bind.customizedmapping.ijson.IJsonSupportTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.250 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.adapters.AdaptersCustomizationCDITest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.787 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.SerializersCustomizationCDITest
-[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.390 s -- in ee.jakarta.tck.json.bind.defaultmapping.collections.CollectionsMappingTest
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.201 s -- in ee.jakarta.tck.json.bind.defaultmapping.jsonptypes.JSONPTypesMappingTest
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.105 s -- in ee.jakarta.tck.json.bind.defaultmapping.generics.GenericsMappingTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in ee.jakarta.tck.json.bind.defaultmapping.enums.EnumMappingTest
-[WARNING] Tests run: 25, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.481 s -- in ee.jakarta.tck.json.bind.defaultmapping.dates.DatesMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.020 s -- in ee.jakarta.tck.json.bind.defaultmapping.nullvalue.NullValueMappingTest
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.229 s -- in ee.jakarta.tck.json.bind.defaultmapping.specifictypes.SpecificTypesMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in ee.jakarta.tck.json.bind.defaultmapping.identifiers.NamesAndIdentifiersMappingTest
-[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.186 s -- in ee.jakarta.tck.json.bind.defaultmapping.classes.ClassesMappingTest
-[WARNING] Tests run: 10, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.224 s -- in ee.jakarta.tck.json.bind.defaultmapping.basictypes.BasicJavaTypesMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s -- in ee.jakarta.tck.json.bind.defaultmapping.untyped.UntypedMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in ee.jakarta.tck.json.bind.defaultmapping.arrays.ArraysMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in ee.jakarta.tck.json.bind.defaultmapping.interfaces.InterfaceMappingTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.050 s -- in ee.jakarta.tck.json.bind.defaultmapping.uniqueness.PropertyUniquenessTest
-[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.003 s -- in ee.jakarta.tck.json.bind.defaultmapping.bignumbers.BigNumbersMappingTest
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.MultipleTypeInfoTest
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.105 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.AnnotationTypeInfoTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.053 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.DefaultPolymorphicMappingTest
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.TypeInfoExceptionsTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s -- in ee.jakarta.tck.json.bind.defaultmapping.attributeorder.AttributeOrderMappingTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.180 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.adapters.AdaptersCustomizationCDITest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.879 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.SerializersCustomizationCDITest
+[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.248 s -- in ee.jakarta.tck.json.bind.defaultmapping.collections.CollectionsMappingTest
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.160 s -- in ee.jakarta.tck.json.bind.defaultmapping.jsonptypes.JSONPTypesMappingTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.095 s -- in ee.jakarta.tck.json.bind.defaultmapping.generics.GenericsMappingTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.065 s -- in ee.jakarta.tck.json.bind.defaultmapping.enums.EnumMappingTest
+[WARNING] Tests run: 25, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.521 s -- in ee.jakarta.tck.json.bind.defaultmapping.dates.DatesMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in ee.jakarta.tck.json.bind.defaultmapping.nullvalue.NullValueMappingTest
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.248 s -- in ee.jakarta.tck.json.bind.defaultmapping.specifictypes.SpecificTypesMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in ee.jakarta.tck.json.bind.defaultmapping.identifiers.NamesAndIdentifiersMappingTest
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.203 s -- in ee.jakarta.tck.json.bind.defaultmapping.classes.ClassesMappingTest
+[WARNING] Tests run: 10, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.186 s -- in ee.jakarta.tck.json.bind.defaultmapping.basictypes.BasicJavaTypesMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in ee.jakarta.tck.json.bind.defaultmapping.untyped.UntypedMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in ee.jakarta.tck.json.bind.defaultmapping.arrays.ArraysMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.050 s -- in ee.jakarta.tck.json.bind.defaultmapping.interfaces.InterfaceMappingTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in ee.jakarta.tck.json.bind.defaultmapping.uniqueness.PropertyUniquenessTest
+[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.008 s -- in ee.jakarta.tck.json.bind.defaultmapping.bignumbers.BigNumbersMappingTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.MultipleTypeInfoTest
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.100 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.AnnotationTypeInfoTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.050 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.DefaultPolymorphicMappingTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.TypeInfoExceptionsTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.077 s -- in ee.jakarta.tck.json.bind.defaultmapping.attributeorder.AttributeOrderMappingTest
 [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in ee.jakarta.tck.json.bind.defaultmapping.ignore.MustIgnoreMappingTest
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.107 s -- in ee.jakarta.tck.json.bind.api.jsonb.JsonbTest
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.116 s -- in ee.jakarta.tck.json.bind.api.annotation.AnnotationTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in ee.jakarta.tck.json.bind.api.exception.JsonbExceptionTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.047 s -- in ee.jakarta.tck.json.bind.api.jsonbadapter.JsonbAdapterTest
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in ee.jakarta.tck.json.bind.api.builder.JsonbBuilderTest
-[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.096 s -- in ee.jakarta.tck.json.bind.api.config.JsonbConfigTest
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.122 s -- in ee.jakarta.tck.json.bind.api.jsonb.JsonbTest
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.160 s -- in ee.jakarta.tck.json.bind.api.annotation.AnnotationTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in ee.jakarta.tck.json.bind.api.exception.JsonbExceptionTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in ee.jakarta.tck.json.bind.api.jsonbadapter.JsonbAdapterTest
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.095 s -- in ee.jakarta.tck.json.bind.api.builder.JsonbBuilderTest
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.090 s -- in ee.jakarta.tck.json.bind.api.config.JsonbConfigTest
 [INFO]
 [INFO] Results:
 [INFO] 
@@ -175,36 +175,36 @@ Stage Name: Jakarta JSON Binding TCK
 
 
 Stage Name: Jakarta JSON Processing TCK
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.640 s -- in ee.jakarta.tck.jsonp.signaturetest.jsonp.JSONPSigTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.339 s -- in ee.jakarta.tck.jsonp.api.jsonstringtests.ClientTests
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.068 s -- in ee.jakarta.tck.jsonp.api.jsonobjecttests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.381 s -- in ee.jakarta.tck.jsonp.api.jsonwriterfactorytests.ClientTests
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.449 s -- in ee.jakarta.tck.jsonp.api.mergetests.MergeTests
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.301 s -- in ee.jakarta.tck.jsonp.api.jsonnumbertests.ClientTests
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.281 s -- in ee.jakarta.tck.jsonp.api.jsonparsereventtests.ClientTests
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.250 s -- in ee.jakarta.tck.jsonp.api.patchtests.PatchTests
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.581 s -- in ee.jakarta.tck.jsonp.api.jsonarraytests.ClientTests
-[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.161 s -- in ee.jakarta.tck.jsonp.api.jsonparsertests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.354 s -- in ee.jakarta.tck.jsonp.api.jsonstreamingtests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.871 s -- in ee.jakarta.tck.jsonp.api.pointertests.PointerTests
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.366 s -- in ee.jakarta.tck.jsonp.api.collectortests.CollectorTests
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.218 s -- in ee.jakarta.tck.jsonp.api.jsoncoding.ClientTests
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 s -- in ee.jakarta.tck.jsonp.api.provider.JsonProviderTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.382 s -- in ee.jakarta.tck.jsonp.api.jsonbuilderfactorytests.ClientTests
-[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.491 s -- in ee.jakarta.tck.jsonp.api.jsonreadertests.ClientTests
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.182 s -- in ee.jakarta.tck.jsonp.api.jsonwritertests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.372 s -- in ee.jakarta.tck.jsonp.api.jsonreaderfactorytests.ClientTests
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.645 s -- in ee.jakarta.tck.jsonp.api.jsonvaluetests.ClientTests
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.973 s -- in ee.jakarta.tck.jsonp.api.jsongeneratortests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.431 s -- in ee.jakarta.tck.jsonp.api.jsongeneratorfactorytests.ClientTests
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.543 s -- in ee.jakarta.tck.jsonp.api.jsonparserfactorytests.ClientTests
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.295 s -- in ee.jakarta.tck.jsonp.api.exceptiontests.ClientTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.949 s -- in ee.jakarta.tck.jsonp.signaturetest.jsonp.JSONPSigTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.282 s -- in ee.jakarta.tck.jsonp.api.jsonstringtests.ClientTests
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.875 s -- in ee.jakarta.tck.jsonp.api.jsonobjecttests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.401 s -- in ee.jakarta.tck.jsonp.api.jsonwriterfactorytests.ClientTests
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.390 s -- in ee.jakarta.tck.jsonp.api.mergetests.MergeTests
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.295 s -- in ee.jakarta.tck.jsonp.api.jsonnumbertests.ClientTests
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.220 s -- in ee.jakarta.tck.jsonp.api.jsonparsereventtests.ClientTests
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.895 s -- in ee.jakarta.tck.jsonp.api.patchtests.PatchTests
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.572 s -- in ee.jakarta.tck.jsonp.api.jsonarraytests.ClientTests
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.827 s -- in ee.jakarta.tck.jsonp.api.jsonparsertests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.361 s -- in ee.jakarta.tck.jsonp.api.jsonstreamingtests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.752 s -- in ee.jakarta.tck.jsonp.api.pointertests.PointerTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.321 s -- in ee.jakarta.tck.jsonp.api.collectortests.CollectorTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.187 s -- in ee.jakarta.tck.jsonp.api.jsoncoding.ClientTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.100 s -- in ee.jakarta.tck.jsonp.api.provider.JsonProviderTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.366 s -- in ee.jakarta.tck.jsonp.api.jsonbuilderfactorytests.ClientTests
+[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.301 s -- in ee.jakarta.tck.jsonp.api.jsonreadertests.ClientTests
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.860 s -- in ee.jakarta.tck.jsonp.api.jsonwritertests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.338 s -- in ee.jakarta.tck.jsonp.api.jsonreaderfactorytests.ClientTests
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.536 s -- in ee.jakarta.tck.jsonp.api.jsonvaluetests.ClientTests
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.736 s -- in ee.jakarta.tck.jsonp.api.jsongeneratortests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.304 s -- in ee.jakarta.tck.jsonp.api.jsongeneratorfactorytests.ClientTests
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.439 s -- in ee.jakarta.tck.jsonp.api.jsonparserfactorytests.ClientTests
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.274 s -- in ee.jakarta.tck.jsonp.api.exceptiontests.ClientTests
 [INFO] 
 [INFO] Results:
 [INFO] 
 [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
 [INFO] 
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.653 s -- in ee.jakarta.tck.jsonp.pluggability.jsonprovidertests.ClientTests
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.655 s -- in ee.jakarta.tck.jsonp.pluggability.jsonprovidertests.ClientTests
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -212,165 +212,165 @@ Stage Name: Jakarta JSON Processing TCK
 
 
 Stage Name: Jakarta RESTful Web Services TCK
-[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.344 s -- in ee.jakarta.tck.ws.rs.api.client.client.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.092 s -- in ee.jakarta.tck.ws.rs.api.client.clientbuilder.JAXRSClientIT
-[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.920 s -- in ee.jakarta.tck.ws.rs.api.client.clientrequestcontext.JAXRSClientIT
-[INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.471 s -- in ee.jakarta.tck.ws.rs.api.client.clientresponsecontext.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.404 s -- in ee.jakarta.tck.ws.rs.api.client.entity.JAXRSClientIT
-[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.319 s -- in ee.jakarta.tck.ws.rs.api.client.invocation.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.056 s -- in ee.jakarta.tck.ws.rs.api.client.invocationcallback.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.088 s -- in ee.jakarta.tck.ws.rs.api.client.responseprocessingexception.JAXRSClientIT
-[INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.297 s -- in ee.jakarta.tck.ws.rs.api.client.webtarget.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in ee.jakarta.tck.ws.rs.api.rs.badrequestexception.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.058 s -- in ee.jakarta.tck.ws.rs.api.rs.bindingpriority.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.257 s -- in ee.jakarta.tck.ws.rs.api.rs.clienterrorexception.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.118 s -- in ee.jakarta.tck.ws.rs.api.rs.core.abstractmultivaluedmap.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.080 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cachecontrol.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configurable.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.255 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configuration.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cookie.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.065 s -- in ee.jakarta.tck.ws.rs.api.rs.core.entitytag.JAXRSClientIT
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in ee.jakarta.tck.ws.rs.api.rs.core.form.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.109 s -- in ee.jakarta.tck.ws.rs.api.rs.core.genericentity.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in ee.jakarta.tck.ws.rs.api.rs.core.generictype.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.259 s -- in ee.jakarta.tck.ws.rs.api.rs.core.link.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.214 s -- in ee.jakarta.tck.ws.rs.api.rs.core.linkbuilder.JAXRSClientIT
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.111 s -- in ee.jakarta.tck.ws.rs.api.rs.core.mediatype.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.075 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedhashmap.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.102 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedmap.JAXRSClientIT
-[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.117 s -- in ee.jakarta.tck.ws.rs.api.rs.core.newcookie.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in ee.jakarta.tck.ws.rs.api.rs.core.nocontentexception.JAXRSClientIT
-[INFO] Tests run: 97, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.684 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsebuilder.BuilderClientIT
-[INFO] Tests run: 85, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.249 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responseclient.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsestatustype.JAXRSClientIT
-[WARNING] Tests run: 126, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.609 s -- in ee.jakarta.tck.ws.rs.api.rs.core.uribuilder.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.081 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variant.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variantlistbuilder.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.248 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.084 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.readerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.create.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.setinstance.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.093 s -- in ee.jakarta.tck.ws.rs.api.rs.forbiddenexception.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.088 s -- in ee.jakarta.tck.ws.rs.api.rs.internalservererrorexception.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.084 s -- in ee.jakarta.tck.ws.rs.api.rs.notacceptableexception.JAXRSClientIT
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.109 s -- in ee.jakarta.tck.ws.rs.api.rs.notallowedexception.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.081 s -- in ee.jakarta.tck.ws.rs.api.rs.notauthorizedexception.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.084 s -- in ee.jakarta.tck.ws.rs.api.rs.notfoundexception.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in ee.jakarta.tck.ws.rs.api.rs.notsupportedexception.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.085 s -- in ee.jakarta.tck.ws.rs.api.rs.processingexception.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.130 s -- in ee.jakarta.tck.ws.rs.api.rs.redirectexception.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 s -- in ee.jakarta.tck.ws.rs.api.rs.runtimetype.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.336 s -- in ee.jakarta.tck.ws.rs.api.rs.servererrorexception.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in ee.jakarta.tck.ws.rs.api.rs.serviceunavailableexception.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.226 s -- in ee.jakarta.tck.ws.rs.api.rs.webapplicationexceptiontest.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.054 s -- in ee.jakarta.tck.ws.rs.ee.resource.java2entity.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.321 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper.DefaultExceptionMapperIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.313 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.mapper.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.967 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.nomapper.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.847 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.cookie.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.966 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.form.plain.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.369 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.header.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.895 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.matrix.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.418 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.path.plain.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.380 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.485 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.query.plain.JAXRSClientIT
-[INFO] Tests run: 147, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 163.7 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.asyncinvoker.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.226 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.clientrequestcontext.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.421 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.invocationbuilder.JAXRSClientIT
-[INFO] Tests run: 98, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.475 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.syncinvoker.JAXRSClientIT
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.892 s -- in ee.jakarta.tck.ws.rs.ee.rs.constrainedto.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.318 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.requestcontext.illegalstate.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.459 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.resourceinfo.JAXRSClientIT
-[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.925 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.responsecontext.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.368 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.809 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.820 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.954 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.application.JAXRSClientIT
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.893 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configurable.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.339 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configuration.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.874 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.headers.JAXRSClientIT
-[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.000 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.request.JAXRSClientIT
-[INFO] Tests run: 68, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.892 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.response.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.355 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.responsebuilder.JAXRSClientIT
-[WARNING] Tests run: 20, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.941 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.uriinfo.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.808 s -- in ee.jakarta.tck.ws.rs.ee.rs.delete.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.960 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.864 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.writerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.898 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.900 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.readerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.947 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.844 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.writerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.920 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.paramconverter.JAXRSClientIT
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.458 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.providers.JAXRSProvidersClientIT
-[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.838 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.JAXRSClientIT
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.786 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.379 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.333 s -- in ee.jakarta.tck.ws.rs.ee.rs.get.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.399 s -- in ee.jakarta.tck.ws.rs.ee.rs.head.JAXRSClientIT
-[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.449 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.305 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.340 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.799 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.312 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.859 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.398 s -- in ee.jakarta.tck.ws.rs.ee.rs.options.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.867 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.JAXRSClientIT
-[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.890 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.738 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.476 s -- in ee.jakarta.tck.ws.rs.ee.rs.produceconsume.JAXRSClientIT
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.279 s -- in ee.jakarta.tck.ws.rs.ee.rs.put.JAXRSClientIT
-[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.491 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.JAXRSClientIT
-[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.202 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.474 s -- in ee.jakarta.tck.ws.rs.jaxrs21.api.client.invocationbuilder.JAXRSClientIT
-[WARNING] Tests run: 57, Failures: 0, Errors: 0, Skipped: 57, Time elapsed: 2.775 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.async.JAXRSClientIT
-[WARNING] Tests run: 31, Failures: 0, Errors: 0, Skipped: 29, Time elapsed: 2.754 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.rx.JAXRSClientIT
-[WARNING] Tests run: 98, Failures: 0, Errors: 0, Skipped: 39, Time elapsed: 2.437 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.rxinvoker.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.351 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.patch.server.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.448 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.priority.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.183 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.ssebroadcaster.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.86 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsink.JAXRSClientIT
-[WARNING] Tests run: 15, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 33.00 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsource.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.275 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.classsubresourcelocator.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.442 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.completionstage.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.955 s -- in ee.jakarta.tck.ws.rs.jaxrs31.ee.multipart.MultipartSupportIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.442 s -- in ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.434 s -- in ee.jakarta.tck.ws.rs.jaxrs40.ee.rs.core.uriinfo.UriInfo40ClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.351 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.applicationpath.JAXRSClientIT
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.355 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.core.streamingoutput.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.458 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.ext.paramconverter.autodiscovery.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.496 s -- in ee.jakarta.tck.ws.rs.signaturetest.jaxrs.JAXRSSigTestIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.846 s -- in ee.jakarta.tck.ws.rs.spec.client.exceptions.ClientExceptionsIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in ee.jakarta.tck.ws.rs.spec.client.instance.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.392 s -- in ee.jakarta.tck.ws.rs.spec.client.invocations.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.403 s -- in ee.jakarta.tck.ws.rs.spec.client.resource.JAXRSClientIT
-[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.934 s -- in ee.jakarta.tck.ws.rs.spec.client.typedentities.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.623 s -- in ee.jakarta.tck.ws.rs.spec.client.webtarget.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.260 s -- in ee.jakarta.tck.ws.rs.spec.context.client.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.423 s -- in ee.jakarta.tck.ws.rs.spec.context.server.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.890 s -- in ee.jakarta.tck.ws.rs.spec.contextprovider.JsonbContextProviderIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.393 s -- in ee.jakarta.tck.ws.rs.spec.filter.dynamicfeature.JAXRSClientIT
-[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.935 s -- in ee.jakarta.tck.ws.rs.spec.filter.exception.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.373 s -- in ee.jakarta.tck.ws.rs.spec.filter.globalbinding.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.390 s -- in ee.jakarta.tck.ws.rs.spec.filter.lastvalue.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.377 s -- in ee.jakarta.tck.ws.rs.spec.filter.namebinding.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.379 s -- in ee.jakarta.tck.ws.rs.spec.inheritance.JAXRSClientIT
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.917 s -- in ee.jakarta.tck.ws.rs.spec.provider.exceptionmapper.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.419 s -- in ee.jakarta.tck.ws.rs.spec.provider.reader.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.370 s -- in ee.jakarta.tck.ws.rs.spec.provider.sort.JAXRSClientIT
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.435 s -- in ee.jakarta.tck.ws.rs.spec.provider.standard.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.420 s -- in ee.jakarta.tck.ws.rs.spec.provider.standardwithjaxrsclient.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.397 s -- in ee.jakarta.tck.ws.rs.spec.provider.visibility.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.905 s -- in ee.jakarta.tck.ws.rs.spec.provider.writer.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.422 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.351 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.subclass.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.428 s -- in ee.jakarta.tck.ws.rs.spec.resource.locator.JAXRSClientIT
-[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.838 s -- in ee.jakarta.tck.ws.rs.spec.resource.requestmatching.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.417 s -- in ee.jakarta.tck.ws.rs.spec.resource.responsemediatype.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.395 s -- in ee.jakarta.tck.ws.rs.spec.resource.valueofandfromstring.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.405 s -- in ee.jakarta.tck.ws.rs.spec.resourceconstructor.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.467 s -- in ee.jakarta.tck.ws.rs.spec.returntype.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.390 s -- in ee.jakarta.tck.ws.rs.spec.template.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in ee.jakarta.tck.ws.rs.uribuilder.UriBuilderIT
+[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.173 s -- in ee.jakarta.tck.ws.rs.api.client.client.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.076 s -- in ee.jakarta.tck.ws.rs.api.client.clientbuilder.JAXRSClientIT
+[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.735 s -- in ee.jakarta.tck.ws.rs.api.client.clientrequestcontext.JAXRSClientIT
+[INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.302 s -- in ee.jakarta.tck.ws.rs.api.client.clientresponsecontext.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.635 s -- in ee.jakarta.tck.ws.rs.api.client.entity.JAXRSClientIT
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.859 s -- in ee.jakarta.tck.ws.rs.api.client.invocation.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s -- in ee.jakarta.tck.ws.rs.api.client.invocationcallback.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s -- in ee.jakarta.tck.ws.rs.api.client.responseprocessingexception.JAXRSClientIT
+[INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.385 s -- in ee.jakarta.tck.ws.rs.api.client.webtarget.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s -- in ee.jakarta.tck.ws.rs.api.rs.badrequestexception.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in ee.jakarta.tck.ws.rs.api.rs.bindingpriority.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.317 s -- in ee.jakarta.tck.ws.rs.api.rs.clienterrorexception.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.212 s -- in ee.jakarta.tck.ws.rs.api.rs.core.abstractmultivaluedmap.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.102 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cachecontrol.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.090 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configurable.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.219 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configuration.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cookie.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in ee.jakarta.tck.ws.rs.api.rs.core.entitytag.JAXRSClientIT
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in ee.jakarta.tck.ws.rs.api.rs.core.form.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.074 s -- in ee.jakarta.tck.ws.rs.api.rs.core.genericentity.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in ee.jakarta.tck.ws.rs.api.rs.core.generictype.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.195 s -- in ee.jakarta.tck.ws.rs.api.rs.core.link.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.183 s -- in ee.jakarta.tck.ws.rs.api.rs.core.linkbuilder.JAXRSClientIT
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.081 s -- in ee.jakarta.tck.ws.rs.api.rs.core.mediatype.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedhashmap.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.090 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedmap.JAXRSClientIT
+[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.105 s -- in ee.jakarta.tck.ws.rs.api.rs.core.newcookie.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.059 s -- in ee.jakarta.tck.ws.rs.api.rs.core.nocontentexception.JAXRSClientIT
+[INFO] Tests run: 97, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.318 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsebuilder.BuilderClientIT
+[INFO] Tests run: 85, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.287 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responseclient.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsestatustype.JAXRSClientIT
+[WARNING] Tests run: 126, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.495 s -- in ee.jakarta.tck.ws.rs.api.rs.core.uribuilder.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.064 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variant.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variantlistbuilder.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.269 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.099 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.readerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.create.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.setinstance.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s -- in ee.jakarta.tck.ws.rs.api.rs.forbiddenexception.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in ee.jakarta.tck.ws.rs.api.rs.internalservererrorexception.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 s -- in ee.jakarta.tck.ws.rs.api.rs.notacceptableexception.JAXRSClientIT
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.104 s -- in ee.jakarta.tck.ws.rs.api.rs.notallowedexception.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s -- in ee.jakarta.tck.ws.rs.api.rs.notauthorizedexception.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s -- in ee.jakarta.tck.ws.rs.api.rs.notfoundexception.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in ee.jakarta.tck.ws.rs.api.rs.notsupportedexception.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.051 s -- in ee.jakarta.tck.ws.rs.api.rs.processingexception.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s -- in ee.jakarta.tck.ws.rs.api.rs.redirectexception.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in ee.jakarta.tck.ws.rs.api.rs.runtimetype.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.111 s -- in ee.jakarta.tck.ws.rs.api.rs.servererrorexception.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in ee.jakarta.tck.ws.rs.api.rs.serviceunavailableexception.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.167 s -- in ee.jakarta.tck.ws.rs.api.rs.webapplicationexceptiontest.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.348 s -- in ee.jakarta.tck.ws.rs.ee.resource.java2entity.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.255 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper.DefaultExceptionMapperIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.981 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.mapper.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.413 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.nomapper.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.328 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.cookie.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.474 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.form.plain.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.318 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.header.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.435 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.matrix.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.442 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.path.plain.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.382 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.321 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.query.plain.JAXRSClientIT
+[INFO] Tests run: 147, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 162.3 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.asyncinvoker.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.721 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.clientrequestcontext.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.902 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.invocationbuilder.JAXRSClientIT
+[INFO] Tests run: 98, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.402 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.syncinvoker.JAXRSClientIT
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.871 s -- in ee.jakarta.tck.ws.rs.ee.rs.constrainedto.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.903 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.requestcontext.illegalstate.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.438 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.resourceinfo.JAXRSClientIT
+[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.947 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.responsecontext.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.296 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.334 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.297 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.450 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.application.JAXRSClientIT
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.853 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configurable.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.480 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configuration.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.798 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.headers.JAXRSClientIT
+[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.942 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.request.JAXRSClientIT
+[INFO] Tests run: 68, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.430 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.response.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.367 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.responsebuilder.JAXRSClientIT
+[WARNING] Tests run: 20, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.901 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.uriinfo.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.355 s -- in ee.jakarta.tck.ws.rs.ee.rs.delete.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.922 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.900 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.writerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.940 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.875 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.readerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.909 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.996 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.writerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.824 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.paramconverter.JAXRSClientIT
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.926 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.providers.JAXRSProvidersClientIT
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.835 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.JAXRSClientIT
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.897 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.201 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.395 s -- in ee.jakarta.tck.ws.rs.ee.rs.get.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.420 s -- in ee.jakarta.tck.ws.rs.ee.rs.head.JAXRSClientIT
+[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.934 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.233 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.307 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.979 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.248 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.399 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.288 s -- in ee.jakarta.tck.ws.rs.ee.rs.options.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.912 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.JAXRSClientIT
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.819 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.292 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.899 s -- in ee.jakarta.tck.ws.rs.ee.rs.produceconsume.JAXRSClientIT
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.453 s -- in ee.jakarta.tck.ws.rs.ee.rs.put.JAXRSClientIT
+[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.821 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.JAXRSClientIT
+[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.319 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.457 s -- in ee.jakarta.tck.ws.rs.jaxrs21.api.client.invocationbuilder.JAXRSClientIT
+[WARNING] Tests run: 57, Failures: 0, Errors: 0, Skipped: 57, Time elapsed: 2.726 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.async.JAXRSClientIT
+[WARNING] Tests run: 31, Failures: 0, Errors: 0, Skipped: 29, Time elapsed: 2.829 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.rx.JAXRSClientIT
+[WARNING] Tests run: 98, Failures: 0, Errors: 0, Skipped: 39, Time elapsed: 2.384 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.rxinvoker.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.403 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.patch.server.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.404 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.priority.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.886 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.ssebroadcaster.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.92 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsink.JAXRSClientIT
+[WARNING] Tests run: 15, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 32.61 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsource.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.742 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.classsubresourcelocator.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.344 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.completionstage.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.465 s -- in ee.jakarta.tck.ws.rs.jaxrs31.ee.multipart.MultipartSupportIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.325 s -- in ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.396 s -- in ee.jakarta.tck.ws.rs.jaxrs40.ee.rs.core.uriinfo.UriInfo40ClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.455 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.applicationpath.JAXRSClientIT
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.439 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.core.streamingoutput.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.320 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.ext.paramconverter.autodiscovery.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.183 s -- in ee.jakarta.tck.ws.rs.signaturetest.jaxrs.JAXRSSigTestIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.264 s -- in ee.jakarta.tck.ws.rs.spec.client.exceptions.ClientExceptionsIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in ee.jakarta.tck.ws.rs.spec.client.instance.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.411 s -- in ee.jakarta.tck.ws.rs.spec.client.invocations.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.387 s -- in ee.jakarta.tck.ws.rs.spec.client.resource.JAXRSClientIT
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.870 s -- in ee.jakarta.tck.ws.rs.spec.client.typedentities.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.743 s -- in ee.jakarta.tck.ws.rs.spec.client.webtarget.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.164 s -- in ee.jakarta.tck.ws.rs.spec.context.client.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.410 s -- in ee.jakarta.tck.ws.rs.spec.context.server.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.841 s -- in ee.jakarta.tck.ws.rs.spec.contextprovider.JsonbContextProviderIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.431 s -- in ee.jakarta.tck.ws.rs.spec.filter.dynamicfeature.JAXRSClientIT
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.898 s -- in ee.jakarta.tck.ws.rs.spec.filter.exception.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.387 s -- in ee.jakarta.tck.ws.rs.spec.filter.globalbinding.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.433 s -- in ee.jakarta.tck.ws.rs.spec.filter.lastvalue.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.371 s -- in ee.jakarta.tck.ws.rs.spec.filter.namebinding.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.473 s -- in ee.jakarta.tck.ws.rs.spec.inheritance.JAXRSClientIT
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.344 s -- in ee.jakarta.tck.ws.rs.spec.provider.exceptionmapper.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.430 s -- in ee.jakarta.tck.ws.rs.spec.provider.reader.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.384 s -- in ee.jakarta.tck.ws.rs.spec.provider.sort.JAXRSClientIT
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.914 s -- in ee.jakarta.tck.ws.rs.spec.provider.standard.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.391 s -- in ee.jakarta.tck.ws.rs.spec.provider.standardwithjaxrsclient.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.430 s -- in ee.jakarta.tck.ws.rs.spec.provider.visibility.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.891 s -- in ee.jakarta.tck.ws.rs.spec.provider.writer.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.330 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.446 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.subclass.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.406 s -- in ee.jakarta.tck.ws.rs.spec.resource.locator.JAXRSClientIT
+[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.912 s -- in ee.jakarta.tck.ws.rs.spec.resource.requestmatching.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.376 s -- in ee.jakarta.tck.ws.rs.spec.resource.responsemediatype.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.442 s -- in ee.jakarta.tck.ws.rs.spec.resource.valueofandfromstring.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.350 s -- in ee.jakarta.tck.ws.rs.spec.resourceconstructor.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.424 s -- in ee.jakarta.tck.ws.rs.spec.returntype.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.363 s -- in ee.jakarta.tck.ws.rs.spec.template.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in ee.jakarta.tck.ws.rs.uribuilder.UriBuilderIT
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -381,6 +381,6 @@ Stage Name: Jakarta RESTful Web Services TCK
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time: 11:40 min
+[INFO] Total time: 11:28 min
 
 ----

--- a/jakartaee/11/coreprofile/24.0.0.11-beta-Java21-TCKResults.adoc
+++ b/jakartaee/11/coreprofile/24.0.0.11-beta-Java21-TCKResults.adoc
@@ -16,7 +16,7 @@ https://jakarta.ee/specifications/coreprofile/11[Jakarta EE Core Profile 11]
 * TCK Version, digital SHA-256 fingerprint and download URL:
 +
 https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/jakarta-core-profile-tck-11.0.0.zip[Jakarta EE Core Profile TCK 11.0 (Staged Release)],
-SHA-256: `cd5d039adcb17a626845ee43c03e4ff11fbdec6738afb251bc3b1778c389e1c2`
+SHA-256: `5722bac4f1af78e93ede95feaa448aa0bc19934d0871415c25dd45ffa8c5d1a5`
 
 * Public URL of TCK Results Summary:
 +
@@ -69,10 +69,10 @@ Test results:
 ----
 
 Stage Name: Jakarta Core Profile TCK
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.71 s -- in ee.jakarta.tck.core.json.ApplicationJsonpIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.222 s -- in ee.jakarta.tck.core.jsonb.JsonbApplicationIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.274 s -- in ee.jakarta.tck.core.rest.context.app.ApplicationContextIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.952 s -- in ee.jakarta.tck.core.rest.jsonb.cdi.CustomJsonbSerializationIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.96 s -- in ee.jakarta.tck.core.json.ApplicationJsonpIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.716 s -- in ee.jakarta.tck.core.jsonb.JsonbApplicationIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.907 s -- in ee.jakarta.tck.core.rest.context.app.ApplicationContextIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.789 s -- in ee.jakarta.tck.core.rest.jsonb.cdi.CustomJsonbSerializationIT
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -83,11 +83,11 @@ Stage Name: Jakarta Core Profile TCK
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time: 01:23 min
+[INFO] Total time: 01:54 min
 
 
 Stage Name: Jakarta Annotations TCK
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.988 s -- in ee.jakarta.tck.annotations.signaturetest.CAJSigTestIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.48 s -- in ee.jakarta.tck.annotations.signaturetest.CAJSigTestIT
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -98,11 +98,11 @@ Stage Name: Jakarta Annotations TCK
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time: 46.135 s
+[INFO] Total time: 01:07 min
 
 
 Stage Name: Jakarta Contexts and Dependency Injection TCK
-[INFO] Tests run: 779, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 872.441 s - in TestSuite
+[INFO] Tests run: 779, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,081.133 s - in TestSuite
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -110,7 +110,7 @@ Stage Name: Jakarta Contexts and Dependency Injection TCK
 [INFO] 
 [INFO] /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/surefire-reports/sigtest/TEST-liberty-cdi-tck-runner-4.1.0.xml: 0 failures in /home/jazz_build/Build/jbe/build/dev/ee.jakarta.ee4j8.cts.liberty_fat.cdi/autoFVT/publish/cts_runner/docker/was-cts/jakarta/conf/cdi-tck/target/api-signature/cdi-api-jdk17.sig
 
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.167 s -- in org.jboss.weld.langmodel.tck.LangModelTckTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.391 s -- in org.jboss.weld.langmodel.tck.LangModelTckTest
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -118,7 +118,7 @@ Stage Name: Jakarta Contexts and Dependency Injection TCK
 
 
 Stage Name: Jakarta Dependency Injection TCK
-[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.298 s -- in weld.SampleBootstrapTCK
+[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.371 s -- in weld.SampleBootstrapTCK
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -126,48 +126,48 @@ Stage Name: Jakarta Dependency Injection TCK
 
 
 Stage Name: Jakarta JSON Binding TCK
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.295 s -- in ee.jakarta.tck.json.bind.signaturetest.jsonb.JSONBSigTest
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.700 s -- in ee.jakarta.tck.json.bind.customizedmapping.numberformat.NumberFormatCustomizationTest
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.304 s -- in ee.jakarta.tck.json.bind.customizedmapping.nullhandling.NullHandlingCustomizationTest
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.408 s -- in ee.jakarta.tck.json.bind.customizedmapping.dateformat.DateFormatCustomizationTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.086 s -- in ee.jakarta.tck.json.bind.customizedmapping.visibility.VisibilityCustomizationTest
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.355 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertynames.PropertyNameCustomizationTest
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.203 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.OptionalCreatorParametersTest
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.152 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.InstantiationCustomizationTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s -- in ee.jakarta.tck.json.bind.customizedmapping.adapters.AdaptersCustomizationTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.081 s -- in ee.jakarta.tck.json.bind.customizedmapping.serializers.SerializersCustomizationTest
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.209 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertyorder.PropertyOrderCustomizationTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s -- in ee.jakarta.tck.json.bind.customizedmapping.binarydata.BinaryDataCustomizationTest
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.189 s -- in ee.jakarta.tck.json.bind.customizedmapping.ijson.IJsonSupportTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.387 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.adapters.AdaptersCustomizationCDITest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.935 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.SerializersCustomizationCDITest
-[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.282 s -- in ee.jakarta.tck.json.bind.defaultmapping.collections.CollectionsMappingTest
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.114 s -- in ee.jakarta.tck.json.bind.defaultmapping.jsonptypes.JSONPTypesMappingTest
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.154 s -- in ee.jakarta.tck.json.bind.defaultmapping.generics.GenericsMappingTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.087 s -- in ee.jakarta.tck.json.bind.defaultmapping.enums.EnumMappingTest
-[WARNING] Tests run: 25, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.906 s -- in ee.jakarta.tck.json.bind.defaultmapping.dates.DatesMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in ee.jakarta.tck.json.bind.defaultmapping.nullvalue.NullValueMappingTest
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.350 s -- in ee.jakarta.tck.json.bind.defaultmapping.specifictypes.SpecificTypesMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s -- in ee.jakarta.tck.json.bind.defaultmapping.identifiers.NamesAndIdentifiersMappingTest
-[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.273 s -- in ee.jakarta.tck.json.bind.defaultmapping.classes.ClassesMappingTest
-[WARNING] Tests run: 10, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.219 s -- in ee.jakarta.tck.json.bind.defaultmapping.basictypes.BasicJavaTypesMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in ee.jakarta.tck.json.bind.defaultmapping.untyped.UntypedMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s -- in ee.jakarta.tck.json.bind.defaultmapping.arrays.ArraysMappingTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in ee.jakarta.tck.json.bind.defaultmapping.interfaces.InterfaceMappingTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in ee.jakarta.tck.json.bind.defaultmapping.uniqueness.PropertyUniquenessTest
-[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.003 s -- in ee.jakarta.tck.json.bind.defaultmapping.bignumbers.BigNumbersMappingTest
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.074 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.MultipleTypeInfoTest
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.042 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.AnnotationTypeInfoTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.DefaultPolymorphicMappingTest
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.TypeInfoExceptionsTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in ee.jakarta.tck.json.bind.defaultmapping.attributeorder.AttributeOrderMappingTest
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s -- in ee.jakarta.tck.json.bind.defaultmapping.ignore.MustIgnoreMappingTest
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s -- in ee.jakarta.tck.json.bind.api.jsonb.JsonbTest
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.050 s -- in ee.jakarta.tck.json.bind.api.annotation.AnnotationTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.40 s -- in ee.jakarta.tck.json.bind.signaturetest.jsonb.JSONBSigTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.039 s -- in ee.jakarta.tck.json.bind.customizedmapping.numberformat.NumberFormatCustomizationTest
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.346 s -- in ee.jakarta.tck.json.bind.customizedmapping.nullhandling.NullHandlingCustomizationTest
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.578 s -- in ee.jakarta.tck.json.bind.customizedmapping.dateformat.DateFormatCustomizationTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.134 s -- in ee.jakarta.tck.json.bind.customizedmapping.visibility.VisibilityCustomizationTest
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.556 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertynames.PropertyNameCustomizationTest
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.364 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.OptionalCreatorParametersTest
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.289 s -- in ee.jakarta.tck.json.bind.customizedmapping.instantiation.InstantiationCustomizationTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.104 s -- in ee.jakarta.tck.json.bind.customizedmapping.adapters.AdaptersCustomizationTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.090 s -- in ee.jakarta.tck.json.bind.customizedmapping.serializers.SerializersCustomizationTest
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.389 s -- in ee.jakarta.tck.json.bind.customizedmapping.propertyorder.PropertyOrderCustomizationTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.103 s -- in ee.jakarta.tck.json.bind.customizedmapping.binarydata.BinaryDataCustomizationTest
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.270 s -- in ee.jakarta.tck.json.bind.customizedmapping.ijson.IJsonSupportTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.334 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.adapters.AdaptersCustomizationCDITest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.176 s -- in ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.SerializersCustomizationCDITest
+[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.403 s -- in ee.jakarta.tck.json.bind.defaultmapping.collections.CollectionsMappingTest
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.272 s -- in ee.jakarta.tck.json.bind.defaultmapping.jsonptypes.JSONPTypesMappingTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.218 s -- in ee.jakarta.tck.json.bind.defaultmapping.generics.GenericsMappingTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.057 s -- in ee.jakarta.tck.json.bind.defaultmapping.enums.EnumMappingTest
+[WARNING] Tests run: 25, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.916 s -- in ee.jakarta.tck.json.bind.defaultmapping.dates.DatesMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.020 s -- in ee.jakarta.tck.json.bind.defaultmapping.nullvalue.NullValueMappingTest
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.421 s -- in ee.jakarta.tck.json.bind.defaultmapping.specifictypes.SpecificTypesMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s -- in ee.jakarta.tck.json.bind.defaultmapping.identifiers.NamesAndIdentifiersMappingTest
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.330 s -- in ee.jakarta.tck.json.bind.defaultmapping.classes.ClassesMappingTest
+[WARNING] Tests run: 10, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.452 s -- in ee.jakarta.tck.json.bind.defaultmapping.basictypes.BasicJavaTypesMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in ee.jakarta.tck.json.bind.defaultmapping.untyped.UntypedMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 s -- in ee.jakarta.tck.json.bind.defaultmapping.arrays.ArraysMappingTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in ee.jakarta.tck.json.bind.defaultmapping.interfaces.InterfaceMappingTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in ee.jakarta.tck.json.bind.defaultmapping.uniqueness.PropertyUniquenessTest
+[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.040 s -- in ee.jakarta.tck.json.bind.defaultmapping.bignumbers.BigNumbersMappingTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.092 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.MultipleTypeInfoTest
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.056 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.AnnotationTypeInfoTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.DefaultPolymorphicMappingTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.040 s -- in ee.jakarta.tck.json.bind.defaultmapping.polymorphictypes.TypeInfoExceptionsTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s -- in ee.jakarta.tck.json.bind.defaultmapping.attributeorder.AttributeOrderMappingTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 s -- in ee.jakarta.tck.json.bind.defaultmapping.ignore.MustIgnoreMappingTest
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.153 s -- in ee.jakarta.tck.json.bind.api.jsonb.JsonbTest
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.176 s -- in ee.jakarta.tck.json.bind.api.annotation.AnnotationTest
 [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in ee.jakarta.tck.json.bind.api.exception.JsonbExceptionTest
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.044 s -- in ee.jakarta.tck.json.bind.api.jsonbadapter.JsonbAdapterTest
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s -- in ee.jakarta.tck.json.bind.api.builder.JsonbBuilderTest
-[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s -- in ee.jakarta.tck.json.bind.api.config.JsonbConfigTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.065 s -- in ee.jakarta.tck.json.bind.api.jsonbadapter.JsonbAdapterTest
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.108 s -- in ee.jakarta.tck.json.bind.api.builder.JsonbBuilderTest
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.094 s -- in ee.jakarta.tck.json.bind.api.config.JsonbConfigTest
 [INFO]
 [INFO] Results:
 [INFO] 
@@ -175,36 +175,36 @@ Stage Name: Jakarta JSON Binding TCK
 
 
 Stage Name: Jakarta JSON Processing TCK
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.829 s -- in ee.jakarta.tck.jsonp.signaturetest.jsonp.JSONPSigTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.311 s -- in ee.jakarta.tck.jsonp.api.jsonstringtests.ClientTests
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.850 s -- in ee.jakarta.tck.jsonp.api.jsonobjecttests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.416 s -- in ee.jakarta.tck.jsonp.api.jsonwriterfactorytests.ClientTests
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.476 s -- in ee.jakarta.tck.jsonp.api.mergetests.MergeTests
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.324 s -- in ee.jakarta.tck.jsonp.api.jsonnumbertests.ClientTests
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.260 s -- in ee.jakarta.tck.jsonp.api.jsonparsereventtests.ClientTests
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.294 s -- in ee.jakarta.tck.jsonp.api.patchtests.PatchTests
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.320 s -- in ee.jakarta.tck.jsonp.api.jsonarraytests.ClientTests
-[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.167 s -- in ee.jakarta.tck.jsonp.api.jsonparsertests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.365 s -- in ee.jakarta.tck.jsonp.api.jsonstreamingtests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.749 s -- in ee.jakarta.tck.jsonp.api.pointertests.PointerTests
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.342 s -- in ee.jakarta.tck.jsonp.api.collectortests.CollectorTests
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.212 s -- in ee.jakarta.tck.jsonp.api.jsoncoding.ClientTests
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.085 s -- in ee.jakarta.tck.jsonp.api.provider.JsonProviderTest
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.359 s -- in ee.jakarta.tck.jsonp.api.jsonbuilderfactorytests.ClientTests
-[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.389 s -- in ee.jakarta.tck.jsonp.api.jsonreadertests.ClientTests
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.894 s -- in ee.jakarta.tck.jsonp.api.jsonwritertests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.349 s -- in ee.jakarta.tck.jsonp.api.jsonreaderfactorytests.ClientTests
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.542 s -- in ee.jakarta.tck.jsonp.api.jsonvaluetests.ClientTests
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.990 s -- in ee.jakarta.tck.jsonp.api.jsongeneratortests.ClientTests
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.433 s -- in ee.jakarta.tck.jsonp.api.jsongeneratorfactorytests.ClientTests
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.480 s -- in ee.jakarta.tck.jsonp.api.jsonparserfactorytests.ClientTests
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.272 s -- in ee.jakarta.tck.jsonp.api.exceptiontests.ClientTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.19 s -- in ee.jakarta.tck.jsonp.signaturetest.jsonp.JSONPSigTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.410 s -- in ee.jakarta.tck.jsonp.api.jsonstringtests.ClientTests
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.360 s -- in ee.jakarta.tck.jsonp.api.jsonobjecttests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.562 s -- in ee.jakarta.tck.jsonp.api.jsonwriterfactorytests.ClientTests
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.661 s -- in ee.jakarta.tck.jsonp.api.mergetests.MergeTests
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.401 s -- in ee.jakarta.tck.jsonp.api.jsonnumbertests.ClientTests
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.422 s -- in ee.jakarta.tck.jsonp.api.jsonparsereventtests.ClientTests
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.798 s -- in ee.jakarta.tck.jsonp.api.patchtests.PatchTests
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.067 s -- in ee.jakarta.tck.jsonp.api.jsonarraytests.ClientTests
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.197 s -- in ee.jakarta.tck.jsonp.api.jsonparsertests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.479 s -- in ee.jakarta.tck.jsonp.api.jsonstreamingtests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.092 s -- in ee.jakarta.tck.jsonp.api.pointertests.PointerTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.467 s -- in ee.jakarta.tck.jsonp.api.collectortests.CollectorTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.296 s -- in ee.jakarta.tck.jsonp.api.jsoncoding.ClientTests
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 s -- in ee.jakarta.tck.jsonp.api.provider.JsonProviderTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.480 s -- in ee.jakarta.tck.jsonp.api.jsonbuilderfactorytests.ClientTests
+[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.692 s -- in ee.jakarta.tck.jsonp.api.jsonreadertests.ClientTests
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.268 s -- in ee.jakarta.tck.jsonp.api.jsonwritertests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.487 s -- in ee.jakarta.tck.jsonp.api.jsonreaderfactorytests.ClientTests
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.774 s -- in ee.jakarta.tck.jsonp.api.jsonvaluetests.ClientTests
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.255 s -- in ee.jakarta.tck.jsonp.api.jsongeneratortests.ClientTests
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.473 s -- in ee.jakarta.tck.jsonp.api.jsongeneratorfactorytests.ClientTests
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.576 s -- in ee.jakarta.tck.jsonp.api.jsonparserfactorytests.ClientTests
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.385 s -- in ee.jakarta.tck.jsonp.api.exceptiontests.ClientTests
 [INFO] 
 [INFO] Results:
 [INFO] 
 [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
 [INFO] 
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.736 s -- in ee.jakarta.tck.jsonp.pluggability.jsonprovidertests.ClientTests
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.941 s -- in ee.jakarta.tck.jsonp.pluggability.jsonprovidertests.ClientTests
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -212,165 +212,165 @@ Stage Name: Jakarta JSON Processing TCK
 
 
 Stage Name: Jakarta RESTful Web Services TCK
-[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.191 s -- in ee.jakarta.tck.ws.rs.api.client.client.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.079 s -- in ee.jakarta.tck.ws.rs.api.client.clientbuilder.JAXRSClientIT
-[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.616 s -- in ee.jakarta.tck.ws.rs.api.client.clientrequestcontext.JAXRSClientIT
-[INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.372 s -- in ee.jakarta.tck.ws.rs.api.client.clientresponsecontext.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.184 s -- in ee.jakarta.tck.ws.rs.api.client.entity.JAXRSClientIT
-[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.773 s -- in ee.jakarta.tck.ws.rs.api.client.invocation.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in ee.jakarta.tck.ws.rs.api.client.invocationcallback.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.020 s -- in ee.jakarta.tck.ws.rs.api.client.responseprocessingexception.JAXRSClientIT
-[INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.319 s -- in ee.jakarta.tck.ws.rs.api.client.webtarget.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in ee.jakarta.tck.ws.rs.api.rs.badrequestexception.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s -- in ee.jakarta.tck.ws.rs.api.rs.bindingpriority.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.403 s -- in ee.jakarta.tck.ws.rs.api.rs.clienterrorexception.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.270 s -- in ee.jakarta.tck.ws.rs.api.rs.core.abstractmultivaluedmap.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cachecontrol.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configurable.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.199 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configuration.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cookie.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in ee.jakarta.tck.ws.rs.api.rs.core.entitytag.JAXRSClientIT
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in ee.jakarta.tck.ws.rs.api.rs.core.form.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.075 s -- in ee.jakarta.tck.ws.rs.api.rs.core.genericentity.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in ee.jakarta.tck.ws.rs.api.rs.core.generictype.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.175 s -- in ee.jakarta.tck.ws.rs.api.rs.core.link.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.122 s -- in ee.jakarta.tck.ws.rs.api.rs.core.linkbuilder.JAXRSClientIT
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.071 s -- in ee.jakarta.tck.ws.rs.api.rs.core.mediatype.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedhashmap.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.079 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedmap.JAXRSClientIT
-[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.102 s -- in ee.jakarta.tck.ws.rs.api.rs.core.newcookie.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in ee.jakarta.tck.ws.rs.api.rs.core.nocontentexception.JAXRSClientIT
-[INFO] Tests run: 97, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.259 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsebuilder.BuilderClientIT
-[INFO] Tests run: 85, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.342 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responseclient.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsestatustype.JAXRSClientIT
-[WARNING] Tests run: 126, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.522 s -- in ee.jakarta.tck.ws.rs.api.rs.core.uribuilder.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.076 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variant.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variantlistbuilder.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.223 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.091 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.readerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.create.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.setinstance.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.067 s -- in ee.jakarta.tck.ws.rs.api.rs.forbiddenexception.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.083 s -- in ee.jakarta.tck.ws.rs.api.rs.internalservererrorexception.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s -- in ee.jakarta.tck.ws.rs.api.rs.notacceptableexception.JAXRSClientIT
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.091 s -- in ee.jakarta.tck.ws.rs.api.rs.notallowedexception.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.079 s -- in ee.jakarta.tck.ws.rs.api.rs.notauthorizedexception.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.083 s -- in ee.jakarta.tck.ws.rs.api.rs.notfoundexception.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in ee.jakarta.tck.ws.rs.api.rs.notsupportedexception.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in ee.jakarta.tck.ws.rs.api.rs.processingexception.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s -- in ee.jakarta.tck.ws.rs.api.rs.redirectexception.JAXRSClientIT
+[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.795 s -- in ee.jakarta.tck.ws.rs.api.client.client.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.161 s -- in ee.jakarta.tck.ws.rs.api.client.clientbuilder.JAXRSClientIT
+[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.046 s -- in ee.jakarta.tck.ws.rs.api.client.clientrequestcontext.JAXRSClientIT
+[INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.713 s -- in ee.jakarta.tck.ws.rs.api.client.clientresponsecontext.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.786 s -- in ee.jakarta.tck.ws.rs.api.client.entity.JAXRSClientIT
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.448 s -- in ee.jakarta.tck.ws.rs.api.client.invocation.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.052 s -- in ee.jakarta.tck.ws.rs.api.client.invocationcallback.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.099 s -- in ee.jakarta.tck.ws.rs.api.client.responseprocessingexception.JAXRSClientIT
+[INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.507 s -- in ee.jakarta.tck.ws.rs.api.client.webtarget.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.151 s -- in ee.jakarta.tck.ws.rs.api.rs.badrequestexception.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in ee.jakarta.tck.ws.rs.api.rs.bindingpriority.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.460 s -- in ee.jakarta.tck.ws.rs.api.rs.clienterrorexception.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.208 s -- in ee.jakarta.tck.ws.rs.api.rs.core.abstractmultivaluedmap.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.104 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cachecontrol.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.080 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configurable.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.316 s -- in ee.jakarta.tck.ws.rs.api.rs.core.configuration.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.109 s -- in ee.jakarta.tck.ws.rs.api.rs.core.cookie.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in ee.jakarta.tck.ws.rs.api.rs.core.entitytag.JAXRSClientIT
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s -- in ee.jakarta.tck.ws.rs.api.rs.core.form.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.095 s -- in ee.jakarta.tck.ws.rs.api.rs.core.genericentity.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in ee.jakarta.tck.ws.rs.api.rs.core.generictype.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.272 s -- in ee.jakarta.tck.ws.rs.api.rs.core.link.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.216 s -- in ee.jakarta.tck.ws.rs.api.rs.core.linkbuilder.JAXRSClientIT
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.170 s -- in ee.jakarta.tck.ws.rs.api.rs.core.mediatype.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.030 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedhashmap.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.103 s -- in ee.jakarta.tck.ws.rs.api.rs.core.multivaluedmap.JAXRSClientIT
+[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.127 s -- in ee.jakarta.tck.ws.rs.api.rs.core.newcookie.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 s -- in ee.jakarta.tck.ws.rs.api.rs.core.nocontentexception.JAXRSClientIT
+[INFO] Tests run: 97, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.935 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsebuilder.BuilderClientIT
+[INFO] Tests run: 85, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.443 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responseclient.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in ee.jakarta.tck.ws.rs.api.rs.core.responsestatustype.JAXRSClientIT
+[WARNING] Tests run: 126, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.650 s -- in ee.jakarta.tck.ws.rs.api.rs.core.uribuilder.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variant.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in ee.jakarta.tck.ws.rs.api.rs.core.variantlistbuilder.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.303 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.099 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.interceptor.reader.readerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.create.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in ee.jakarta.tck.ws.rs.api.rs.ext.runtimedelegate.setinstance.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.089 s -- in ee.jakarta.tck.ws.rs.api.rs.forbiddenexception.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.094 s -- in ee.jakarta.tck.ws.rs.api.rs.internalservererrorexception.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.154 s -- in ee.jakarta.tck.ws.rs.api.rs.notacceptableexception.JAXRSClientIT
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.124 s -- in ee.jakarta.tck.ws.rs.api.rs.notallowedexception.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.098 s -- in ee.jakarta.tck.ws.rs.api.rs.notauthorizedexception.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.091 s -- in ee.jakarta.tck.ws.rs.api.rs.notfoundexception.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in ee.jakarta.tck.ws.rs.api.rs.notsupportedexception.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.171 s -- in ee.jakarta.tck.ws.rs.api.rs.processingexception.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.186 s -- in ee.jakarta.tck.ws.rs.api.rs.redirectexception.JAXRSClientIT
 [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in ee.jakarta.tck.ws.rs.api.rs.runtimetype.JAXRSClientIT
-[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.120 s -- in ee.jakarta.tck.ws.rs.api.rs.servererrorexception.JAXRSClientIT
+[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.404 s -- in ee.jakarta.tck.ws.rs.api.rs.servererrorexception.JAXRSClientIT
 [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in ee.jakarta.tck.ws.rs.api.rs.serviceunavailableexception.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.158 s -- in ee.jakarta.tck.ws.rs.api.rs.webapplicationexceptiontest.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.247 s -- in ee.jakarta.tck.ws.rs.ee.resource.java2entity.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.416 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper.DefaultExceptionMapperIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.860 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.mapper.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.426 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.nomapper.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.430 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.cookie.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.884 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.form.plain.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.402 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.header.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.423 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.matrix.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.293 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.path.plain.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.449 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.plain.JAXRSClientIT
-[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.359 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.query.plain.JAXRSClientIT
-[INFO] Tests run: 147, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 162.2 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.asyncinvoker.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.767 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.clientrequestcontext.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.906 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.invocationbuilder.JAXRSClientIT
-[INFO] Tests run: 98, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.395 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.syncinvoker.JAXRSClientIT
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.879 s -- in ee.jakarta.tck.ws.rs.ee.rs.constrainedto.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.846 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.requestcontext.illegalstate.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.439 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.resourceinfo.JAXRSClientIT
-[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.504 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.responsecontext.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.813 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.329 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.274 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.424 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.application.JAXRSClientIT
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.958 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configurable.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.327 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configuration.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.465 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.headers.JAXRSClientIT
-[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.884 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.request.JAXRSClientIT
-[INFO] Tests run: 68, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.939 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.response.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.365 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.responsebuilder.JAXRSClientIT
-[WARNING] Tests run: 20, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.882 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.uriinfo.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.374 s -- in ee.jakarta.tck.ws.rs.ee.rs.delete.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.876 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.452 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.writerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.882 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.393 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.readerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.002 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.interceptorcontext.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.800 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.writerinterceptorcontext.JAXRSClientIT
-[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.984 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.paramconverter.JAXRSClientIT
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.890 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.providers.JAXRSProvidersClientIT
-[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.856 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.JAXRSClientIT
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.791 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.866 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.383 s -- in ee.jakarta.tck.ws.rs.ee.rs.get.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.408 s -- in ee.jakarta.tck.ws.rs.ee.rs.head.JAXRSClientIT
-[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.822 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.294 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.813 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.947 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.245 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.362 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.359 s -- in ee.jakarta.tck.ws.rs.ee.rs.options.JAXRSClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.901 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.JAXRSClientIT
-[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.326 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.locator.JAXRSLocatorClientIT
-[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.849 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.396 s -- in ee.jakarta.tck.ws.rs.ee.rs.produceconsume.JAXRSClientIT
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.378 s -- in ee.jakarta.tck.ws.rs.ee.rs.put.JAXRSClientIT
-[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.893 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.JAXRSClientIT
-[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.331 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.sub.JAXRSSubClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.398 s -- in ee.jakarta.tck.ws.rs.jaxrs21.api.client.invocationbuilder.JAXRSClientIT
-[WARNING] Tests run: 57, Failures: 0, Errors: 0, Skipped: 57, Time elapsed: 3.222 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.async.JAXRSClientIT
-[WARNING] Tests run: 31, Failures: 0, Errors: 0, Skipped: 29, Time elapsed: 2.795 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.rx.JAXRSClientIT
-[WARNING] Tests run: 98, Failures: 0, Errors: 0, Skipped: 39, Time elapsed: 2.394 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.rxinvoker.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.405 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.patch.server.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.423 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.priority.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.963 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.ssebroadcaster.JAXRSClientIT
-[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.82 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsink.JAXRSClientIT
-[WARNING] Tests run: 15, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 31.99 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsource.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.386 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.classsubresourcelocator.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.399 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.completionstage.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.373 s -- in ee.jakarta.tck.ws.rs.jaxrs31.ee.multipart.MultipartSupportIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.366 s -- in ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.483 s -- in ee.jakarta.tck.ws.rs.jaxrs40.ee.rs.core.uriinfo.UriInfo40ClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.355 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.applicationpath.JAXRSClientIT
-[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.379 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.core.streamingoutput.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.412 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.ext.paramconverter.autodiscovery.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.115 s -- in ee.jakarta.tck.ws.rs.signaturetest.jaxrs.JAXRSSigTestIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.874 s -- in ee.jakarta.tck.ws.rs.spec.client.exceptions.ClientExceptionsIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s -- in ee.jakarta.tck.ws.rs.spec.client.instance.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.373 s -- in ee.jakarta.tck.ws.rs.spec.client.invocations.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.291 s -- in ee.jakarta.tck.ws.rs.spec.client.resource.JAXRSClientIT
-[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.415 s -- in ee.jakarta.tck.ws.rs.spec.client.typedentities.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.927 s -- in ee.jakarta.tck.ws.rs.spec.client.webtarget.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.968 s -- in ee.jakarta.tck.ws.rs.spec.context.client.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.442 s -- in ee.jakarta.tck.ws.rs.spec.context.server.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.897 s -- in ee.jakarta.tck.ws.rs.spec.contextprovider.JsonbContextProviderIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.431 s -- in ee.jakarta.tck.ws.rs.spec.filter.dynamicfeature.JAXRSClientIT
-[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.387 s -- in ee.jakarta.tck.ws.rs.spec.filter.exception.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.400 s -- in ee.jakarta.tck.ws.rs.spec.filter.globalbinding.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.416 s -- in ee.jakarta.tck.ws.rs.spec.filter.lastvalue.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.322 s -- in ee.jakarta.tck.ws.rs.spec.filter.namebinding.JAXRSClientIT
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.430 s -- in ee.jakarta.tck.ws.rs.spec.inheritance.JAXRSClientIT
-[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.412 s -- in ee.jakarta.tck.ws.rs.spec.provider.exceptionmapper.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.392 s -- in ee.jakarta.tck.ws.rs.spec.provider.reader.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.448 s -- in ee.jakarta.tck.ws.rs.spec.provider.sort.JAXRSClientIT
-[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.843 s -- in ee.jakarta.tck.ws.rs.spec.provider.standard.JAXRSClientIT
-[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.421 s -- in ee.jakarta.tck.ws.rs.spec.provider.standardwithjaxrsclient.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.361 s -- in ee.jakarta.tck.ws.rs.spec.provider.visibility.JAXRSClientIT
-[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.915 s -- in ee.jakarta.tck.ws.rs.spec.provider.writer.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.408 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.JAXRSClientIT
-[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.404 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.subclass.JAXRSClientIT
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.407 s -- in ee.jakarta.tck.ws.rs.spec.resource.locator.JAXRSClientIT
-[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.875 s -- in ee.jakarta.tck.ws.rs.spec.resource.requestmatching.JAXRSClientIT
-[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.455 s -- in ee.jakarta.tck.ws.rs.spec.resource.responsemediatype.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.360 s -- in ee.jakarta.tck.ws.rs.spec.resource.valueofandfromstring.JAXRSClientIT
-[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.371 s -- in ee.jakarta.tck.ws.rs.spec.resourceconstructor.JAXRSClientIT
-[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.450 s -- in ee.jakarta.tck.ws.rs.spec.returntype.JAXRSClientIT
-[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.375 s -- in ee.jakarta.tck.ws.rs.spec.template.JAXRSClientIT
-[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in ee.jakarta.tck.ws.rs.uribuilder.UriBuilderIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.180 s -- in ee.jakarta.tck.ws.rs.api.rs.webapplicationexceptiontest.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.48 s -- in ee.jakarta.tck.ws.rs.ee.resource.java2entity.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.036 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.defaultmapper.DefaultExceptionMapperIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.402 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.mapper.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.408 s -- in ee.jakarta.tck.ws.rs.ee.resource.webappexception.nomapper.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.458 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.cookie.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.294 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.form.plain.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.997 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.header.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.857 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.matrix.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.904 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.path.plain.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.891 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.plain.JAXRSClientIT
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.898 s -- in ee.jakarta.tck.ws.rs.ee.rs.beanparam.query.plain.JAXRSClientIT
+[INFO] Tests run: 147, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 164.7 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.asyncinvoker.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.192 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.clientrequestcontext.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.405 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.invocationbuilder.JAXRSClientIT
+[INFO] Tests run: 98, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.892 s -- in ee.jakarta.tck.ws.rs.ee.rs.client.syncinvoker.JAXRSClientIT
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.962 s -- in ee.jakarta.tck.ws.rs.ee.rs.constrainedto.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.414 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.requestcontext.illegalstate.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.880 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.resourceinfo.JAXRSClientIT
+[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.401 s -- in ee.jakarta.tck.ws.rs.ee.rs.container.responsecontext.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.933 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.797 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.354 s -- in ee.jakarta.tck.ws.rs.ee.rs.cookieparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.875 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.application.JAXRSClientIT
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.398 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configurable.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.925 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.configuration.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.962 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.headers.JAXRSClientIT
+[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.301 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.request.JAXRSClientIT
+[INFO] Tests run: 68, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.047 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.response.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.837 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.responsebuilder.JAXRSClientIT
+[WARNING] Tests run: 20, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.934 s -- in ee.jakarta.tck.ws.rs.ee.rs.core.uriinfo.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.332 s -- in ee.jakarta.tck.ws.rs.ee.rs.delete.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.988 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.895 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.clientwriter.writerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.375 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.886 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerreader.readerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.844 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.interceptorcontext.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.883 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.interceptor.containerwriter.writerinterceptorcontext.JAXRSClientIT
+[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.475 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.paramconverter.JAXRSClientIT
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.401 s -- in ee.jakarta.tck.ws.rs.ee.rs.ext.providers.JAXRSProvidersClientIT
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.897 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.JAXRSClientIT
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.308 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.295 s -- in ee.jakarta.tck.ws.rs.ee.rs.formparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.379 s -- in ee.jakarta.tck.ws.rs.ee.rs.get.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.342 s -- in ee.jakarta.tck.ws.rs.ee.rs.head.JAXRSClientIT
+[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.492 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.274 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.828 s -- in ee.jakarta.tck.ws.rs.ee.rs.headerparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.881 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.224 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.861 s -- in ee.jakarta.tck.ws.rs.ee.rs.matrixparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.374 s -- in ee.jakarta.tck.ws.rs.ee.rs.options.JAXRSClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.869 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.JAXRSClientIT
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.266 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.locator.JAXRSLocatorClientIT
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.333 s -- in ee.jakarta.tck.ws.rs.ee.rs.pathparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.899 s -- in ee.jakarta.tck.ws.rs.ee.rs.produceconsume.JAXRSClientIT
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.386 s -- in ee.jakarta.tck.ws.rs.ee.rs.put.JAXRSClientIT
+[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.438 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.JAXRSClientIT
+[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.357 s -- in ee.jakarta.tck.ws.rs.ee.rs.queryparam.sub.JAXRSSubClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.369 s -- in ee.jakarta.tck.ws.rs.jaxrs21.api.client.invocationbuilder.JAXRSClientIT
+[WARNING] Tests run: 57, Failures: 0, Errors: 0, Skipped: 57, Time elapsed: 2.808 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.async.JAXRSClientIT
+[WARNING] Tests run: 31, Failures: 0, Errors: 0, Skipped: 29, Time elapsed: 2.729 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.executor.rx.JAXRSClientIT
+[WARNING] Tests run: 98, Failures: 0, Errors: 0, Skipped: 39, Time elapsed: 2.880 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.client.rxinvoker.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.031 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.patch.server.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.799 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.priority.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.519 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.ssebroadcaster.JAXRSClientIT
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.91 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsink.JAXRSClientIT
+[WARNING] Tests run: 15, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 32.52 s -- in ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsource.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.378 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.classsubresourcelocator.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.421 s -- in ee.jakarta.tck.ws.rs.jaxrs21.spec.completionstage.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.367 s -- in ee.jakarta.tck.ws.rs.jaxrs31.ee.multipart.MultipartSupportIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.414 s -- in ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.366 s -- in ee.jakarta.tck.ws.rs.jaxrs40.ee.rs.core.uriinfo.UriInfo40ClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.426 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.applicationpath.JAXRSClientIT
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.372 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.core.streamingoutput.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.383 s -- in ee.jakarta.tck.ws.rs.servlet3.rs.ext.paramconverter.autodiscovery.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.19 s -- in ee.jakarta.tck.ws.rs.signaturetest.jaxrs.JAXRSSigTestIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.751 s -- in ee.jakarta.tck.ws.rs.spec.client.exceptions.ClientExceptionsIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s -- in ee.jakarta.tck.ws.rs.spec.client.instance.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.884 s -- in ee.jakarta.tck.ws.rs.spec.client.invocations.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.384 s -- in ee.jakarta.tck.ws.rs.spec.client.resource.JAXRSClientIT
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.962 s -- in ee.jakarta.tck.ws.rs.spec.client.typedentities.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.949 s -- in ee.jakarta.tck.ws.rs.spec.client.webtarget.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.370 s -- in ee.jakarta.tck.ws.rs.spec.context.client.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.866 s -- in ee.jakarta.tck.ws.rs.spec.context.server.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.940 s -- in ee.jakarta.tck.ws.rs.spec.contextprovider.JsonbContextProviderIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.389 s -- in ee.jakarta.tck.ws.rs.spec.filter.dynamicfeature.JAXRSClientIT
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.931 s -- in ee.jakarta.tck.ws.rs.spec.filter.exception.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.379 s -- in ee.jakarta.tck.ws.rs.spec.filter.globalbinding.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.411 s -- in ee.jakarta.tck.ws.rs.spec.filter.lastvalue.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.371 s -- in ee.jakarta.tck.ws.rs.spec.filter.namebinding.JAXRSClientIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.388 s -- in ee.jakarta.tck.ws.rs.spec.inheritance.JAXRSClientIT
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.402 s -- in ee.jakarta.tck.ws.rs.spec.provider.exceptionmapper.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.425 s -- in ee.jakarta.tck.ws.rs.spec.provider.reader.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.377 s -- in ee.jakarta.tck.ws.rs.spec.provider.sort.JAXRSClientIT
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.895 s -- in ee.jakarta.tck.ws.rs.spec.provider.standard.JAXRSClientIT
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.514 s -- in ee.jakarta.tck.ws.rs.spec.provider.standardwithjaxrsclient.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.317 s -- in ee.jakarta.tck.ws.rs.spec.provider.visibility.JAXRSClientIT
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.942 s -- in ee.jakarta.tck.ws.rs.spec.provider.writer.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.328 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.JAXRSClientIT
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.433 s -- in ee.jakarta.tck.ws.rs.spec.resource.annotationprecedence.subclass.JAXRSClientIT
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.399 s -- in ee.jakarta.tck.ws.rs.spec.resource.locator.JAXRSClientIT
+[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.411 s -- in ee.jakarta.tck.ws.rs.spec.resource.requestmatching.JAXRSClientIT
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.834 s -- in ee.jakarta.tck.ws.rs.spec.resource.responsemediatype.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.466 s -- in ee.jakarta.tck.ws.rs.spec.resource.valueofandfromstring.JAXRSClientIT
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.394 s -- in ee.jakarta.tck.ws.rs.spec.resourceconstructor.JAXRSClientIT
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.394 s -- in ee.jakarta.tck.ws.rs.spec.returntype.JAXRSClientIT
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.310 s -- in ee.jakarta.tck.ws.rs.spec.template.JAXRSClientIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.020 s -- in ee.jakarta.tck.ws.rs.uribuilder.UriBuilderIT
 [INFO] 
 [INFO] Results:
 [INFO] 
@@ -381,6 +381,6 @@ Stage Name: Jakarta RESTful Web Services TCK
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time: 11:19 min
+[INFO] Total time: 10:03 min
 
 ----


### PR DESCRIPTION
Staging pages:
https://certifications-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/certifications/jakartaee/11/coreprofile/24.0.0.11-beta-Java17-TCKResults.html
https://certifications-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/certifications/jakartaee/11/coreprofile/24.0.0.11-beta-Java21-TCKResults.html

The updated pages have Core TCK SHAs that begin with `5722`.